### PR TITLE
✨ add accept callback option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -88,6 +88,11 @@ CookieConsent.run({
     // path to cookieconsent.css
     cc_theme_css : '<your_path>/cookieconsent.css',
     
+    // optional callback function to call when the visitor accepts the cookie consent
+    cc_accept_callback : function(){
+		console.log('The callback function was called!');
+	},
+    
     // define your own cookie-consent and cookie-policy
     // it's up to you to make it gdpr compliant
     cc_languages : [
@@ -214,6 +219,8 @@ document.body.classList.toggle(my_class);
 - __cc_policy_url__ : (string)
     - *default* : null
     - specify path to your own cookieconsent policy page (eg. https://mydomain.com/cookiepolicy/)
+- __cc_accept_callback__ : (function)
+    - a function to call when the visitor accepts the cookie consent
 - __cc_languages__ : (string) __[REQUIRED]__
     - *default* : [{<en_language_only>}]
     - define (multiple) new languages or override default one (en)

--- a/demo/app.js
+++ b/demo/app.js
@@ -14,6 +14,9 @@
 			cc_policy_url : null,                           // specify your own dedicated cookie policy page url
 			cc_auto_language : true,						// if enabled, overrides cc_current_lang
 			cc_theme_css : "../src/cookieconsent.css",		// path to cookieconsent css
+			cc_accept_callback : function(){
+				console.log('The callback function was called!');
+			},
 			cc_languages : [
 				{
 					lang : 'en',

--- a/src/cookieconsent.js
+++ b/src/cookieconsent.js
@@ -96,6 +96,10 @@
                         _config.cc_policy_url = conf_params['cc_policy_url'];
                     }
 
+                    if(conf_params['cc_accept_callback'] != undefined && typeof conf_params['cc_accept_callback'] == "function"){
+                        _config.cc_accept_callback = conf_params['cc_accept_callback'];
+                    }
+
                     if(conf_params['cc_languages'] != undefined && conf_params['cc_languages'] != null && conf_params['cc_languages'].length > 0){
                         /**
                          * Add each defined custom language
@@ -701,6 +705,10 @@
             }
             _setCookie(_config.cc_cookie_name, "accepted", _config.cc_cookie_expires, 0, 0);
             _setCookie('cc_level', cc_cookie_level, _config.cc_cookie_expires, 0, 0);
+
+            if(typeof _config.cc_accept_callback == "function"){
+                _config.cc_accept_callback();
+            }
         }
 
         /**


### PR DESCRIPTION
Hi @orestbida!  Thank you for creating this awesome plugin!

A [user on Stack Overflow is using it](https://stackoverflow.com/q/64124666/10377586) and has some code that  they only want to run if the visitor accepts the cookie consent.  Do you think adding an optional callback function for cases like this would be a useful feature?

Maybe it would be good to have a callback that fires when the visitor accepts the cookie consent _or_ when the plugin finds that it was already accepted.  That would be useful for this Stack Overflow user's specific use case, but do you think it would be useful in general?

I'd love to hear your thoughts!