### PR TITLE
Use Level 3 `rgba()` color notation instead of Level 4

### DIFF
--- a/src/cookieconsent.css
+++ b/src/cookieconsent.css
@@ -651,7 +651,7 @@ CookieConsent settings modal
     box-sizing: content-box;
     background: #fff;
     background: var(--cc-toggle-knob-bg);
-    box-shadow: 0 1px 2px rgb(24 32 35 / 36%);
+    box-shadow: 0 1px 2px rgba(24, 32, 35, .36);
     transition: transform .25s ease;
     border-radius: 100%;
 }


### PR DESCRIPTION
The rest of this file uses CSS Color Level 3 `rgba()` functional notation, but this one instance uses Level 4 notation. This causes an error in some preprocessors (I noticed it in my Jekyll Sass preprocessor). Might be better to go with the more common notation until Level 4 is better supported.