### PR TITLE
Apply hide_from_bots also to WebDriver (Selenium)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -374,7 +374,7 @@ Below a table which sums up all of the available options (must be passed to the 
 | `autoclear_cookies` 	| boolean  	| false   	| Enable if you want to automatically delete cookies when user opts-out of a specific category inside cookie settings              	|
 | `page_scripts` 	    | boolean  	| false   	| Enable if you want to easily `manage existing <script>` tags. Check [manage third party scripts](#manage-third-party-scripts)     	|
 | `remove_cookie_tables`| boolean  	| false   	| Enable if you want to remove the html cookie tables (but still want to make use of `autoclear_cookies`)     	|
-| `hide_from_bots`      | boolean  	| false   	| Enable if you don't want the plugin to run when a bot/crawler is detected      	|
+| `hide_from_bots`      | boolean  	| false   	| Enable if you don't want the plugin to run when a bot/crawler/webdriver is detected      	|
 | `gui_options`         | object  	| -   	    | Customization option which allows to choose layout, position	and transition. Check [layout options & customization](#layout-options--customization) |
 | __`onAccept`__      	| function 	| -       	| Method run `once` either when:  <br>  1. The moment the cookie consent is accepted <br> 2. After each page load (if cookie consent has already  been accepted)         	|
 | __`onChange`__      	| function 	| -       	| Method run `whenever preferences are modified` (and only if cookie consent has already been accepted)                                                                            	|

--- a/src/cookieconsent.js
+++ b/src/cookieconsent.js
@@ -146,7 +146,8 @@
             }
 
             if(conf_params['hide_from_bots'] === true){
-                is_bot = navigator && navigator.userAgent && /bot|crawl|spider|slurp|teoma/i.test(navigator.userAgent);
+                is_bot = navigator &&
+                    ((navigator.userAgent && /bot|crawl|spider|slurp|teoma/i.test(navigator.userAgent)) || navigator.webdriver);
             }
 
             _config.page_scripts = conf_params['page_scripts'] === true;


### PR DESCRIPTION
Enabling `hide_from_bots` will now not only hide the plugin from crawler bots, but also from WebDriver (Selenium).
The [navigator.webdriver](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/webdriver) property is used for the detection. 

This is useful when end to end tests using Selenium are used, and one don't want the plugin to be run on each page (thus triggering the banner, which would cover some portions of the tested webpage). Also WebDriver could itself be used as a tool for crawlers, so the semantics of the name of flag `hide_from_bots` is still appropriate.