### PR TITLE
Add language autodetection strategy based on `<html lang>`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -94,7 +94,7 @@ A __lightweight__ & __gdpr compliant__ cookie consent plugin written in plain ja
                 page_scripts: true,                        // default: false
 
                 // delay: 0,                               // default: 0
-                // auto_language: false,                   // default: false
+                // auto_language: null                     // default: null; could also be 'browser' or 'document'
                 // autorun: true,                          // default: true
                 // force_consent: false,                   // default: false
                 // hide_from_bots: false,                  // default: false
@@ -219,7 +219,7 @@ A __lightweight__ & __gdpr compliant__ cookie consent plugin written in plain ja
                         page_scripts: true,                        // default: false
 
                         // delay: 0,                               // default: 0
-                        // auto_language: false,                   // default: false
+                        // auto_language: '',                      // default: null; could also be 'browser' or 'document'
                         // autorun: true,                          // default: true
                         // force_consent: false,                   // default: false
                         // hide_from_bots: false,                  // default: false
@@ -427,7 +427,7 @@ Additional methods for an easier management of your scripts and cookie settings 
     // ...
     toggle: {
         value: 'analytics',     // cookie category
-        enabled : false,        // default status
+        enabled: false,         // default status
         readonly: false         // allow to enable/disable
         // reload: 'on_disable',   // allows to reload page when the current cookie category is deselected
     }
@@ -564,7 +564,7 @@ Below a table which sums up all of the available options (must be passed to the 
 | `force_consent`       | boolean   | false     | Enable if you want to block page navigation until user action (check [faq](#faq) for a proper implementation) |
 | `revision`            | number  	| 0   	    | Specify this option to enable revisions. [Check below](#how-to-enablemanage-revisions) for a proper usage |
 | `current_lang`      	| string   	| -       	| Specify one of the languages you have defined (can also be dynamic): `'en'`, `'de'` ...                                           |
-| `auto_language`     	| boolean  	| false   	| Automatically detect language based on the user's browser language, if language is not defined => use specified `current_lang`    |
+| `auto_language`     	| string  	| null  	| Language auto-detection strategy. Null to disable (default), `"browser"` to get user's browser language or `"document"` to read value from `<html lang="...">` of current page. If language is not defined => use specified `current_lang` |
 | `autoclear_cookies` 	| boolean  	| false   	| Enable if you want to automatically delete cookies when user opts-out of a specific category inside cookie settings               |
 | `page_scripts` 	    | boolean  	| false   	| Enable if you want to easily `manage existing <script>` tags. Check [manage third party scripts](#manage-third-party-scripts)     |
 | `remove_cookie_tables`| boolean  	| false   	| Enable if you want to remove the html cookie tables (but still want to make use of `autoclear_cookies`)                           |

--- a/demo/app.js
+++ b/demo/app.js
@@ -14,9 +14,9 @@ cc.run({
     cookie_expiration : 365,                    // default: 182
     page_scripts: true,                         // default: false
 
-    // auto_language : false,                   // default: false
-    // autorun : true,                          // default: true
-    // delay : 0,                               // default: 0
+    // auto_language: null,                     // default: null; could also be 'browser' or 'document'
+    // autorun: true,                           // default: true
+    // delay: 0,                                // default: 0
     // force_consent: false,
     // hide_from_bots: false,                   // default: false
     // remove_cookie_tables: false              // default: false

--- a/demo/app2.js
+++ b/demo/app2.js
@@ -11,9 +11,9 @@ cc.run({
     page_scripts: true,                         // default: false
     force_consent: true,                        // default: false
 
-    // auto_language : false,                   // default: false
-    // autorun : true,                          // default: true
-    // delay : 0,                               // default: 0
+    // auto_language: null,                     // default: null; could also be 'browser' or 'document'
+    // autorun: true,                           // default: true
+    // delay: 0,                                // default: 0
     // hide_from_bots: false,                   // default: false
     // remove_cookie_tables: false              // default: false
     // cookie_domain: location.hostname,        // default: current domain


### PR DESCRIPTION
Ref #114 .

First, internal value of `_config.auto_language` is now normalized to be either:
- `browser` (will use `_getBrowserLang()`) - also `true` is classified as `browser`, to keep backward compatibility
- `document` (will use `document.documentElement.lang`)
- or `null` (disable auto detection), which is default in all other cases (including `false` for backward compatibility). I choose `null` over false to be more type strict - now the value of auto_language is basically nullable string.

After this, the `current_lang` is determined. I also refactored this to be in a separate method.