### PR TITLE
Avoid renaming object properties in Closure compiler

### DIFF
--- a/src/cookieconsent.js
+++ b/src/cookieconsent.js
@@ -18,18 +18,18 @@
         var ENABLE_LOGS = true;
 
         var _config = {
-            current_lang: 'en',
-            auto_language: null,
-            autorun: true,                          // run as soon as loaded
-            cookie_name: 'cc_cookie',
-            cookie_expiration: 182,                 // default: 6 months (in days)
-            cookie_domain: window.location.hostname,       // default: current domain
-            cookie_path: '/',
-            cookie_same_site: 'Lax',
-            use_rfc_cookie: false,
-            autoclear_cookies: true,
-            revision: 0,
-            script_selector: 'data-cookiecategory'
+            'current_lang': 'en',
+            'auto_language': null,
+            'autorun': true,                          // run as soon as loaded
+            'cookie_name': 'cc_cookie',
+            'cookie_expiration': 182,                 // default: 6 months (in days)
+            'cookie_domain': window.location.hostname,       // default: current domain
+            'cookie_path': '/',
+            'cookie_same_site': 'Lax',
+            'use_rfc_cookie': false,
+            'autoclear_cookies': true,
+            'revision': 0,
+            'script_selector': 'data-cookiecategory'
         };
 
         /**


### PR DESCRIPTION
In #113 we added getter for the config values.

However, it does not work properly. The reason is the minified version in `dist/` has the properties renamed, so the _config object actually looks something like this:
```
{
  g: "en", 
  l: null, 
  u: true, 
  i: "cc_cookie",
  v: 365,
  …
}
```


So calls like `cc.getConfig('current_lang')` obviously won't work, because the property was renamed to `g`.

The reason is Closure compiler optimization. One option to avoid this is to have keys of the object quoted, [see StackOverflow](https://stackoverflow.com/a/43824348/464890). Keys would then be preserved from the optimalization.

Another option would be to not use `ADVANCED_OPTIMIZATIONS` level on Closure and use just [SIMPLE_OPTIMIZATIONS](https://developers.google.com/closure/compiler/docs/compilation_levels?csw=1#simple_optimizations). However it would mean a little bit bigger output file. 