### PR TITLE
Added `.validConsent()` API

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "🍪 Simple cross-browser cookie-consent plugin written in vanilla js.",
     "main": "dist/cookieconsent.js",
     "scripts": {
-        "dev": "rollup --config --watch",
+        "dev": "node src/utils/dynamic-reset.js &&rollup --config --watch",
         "build": "node src/utils/dynamic-reset.js &&rollup --config",
         "build:ie11": "set BROWSER=IE&& node src/utils/dynamic-reset.js &&rollup --config"
     },

--- a/src/core/api.js
+++ b/src/core/api.js
@@ -454,6 +454,14 @@ export const api = {
     },
 
     /**
+     * Returns true if consent is valid
+     * @returns {boolean}
+     */
+    validConsent: () => {
+        return !state._invalidConsent;
+    },
+
+    /**
      * Will run once and only if modals do not exist.
      * @param {import("./global").UserConfig} conf
      */


### PR DESCRIPTION
Currently, the only way to see if "consent is valid/given" is by retrieving the plugin's cookie. Not reliable.

Check if consent is valid using the plugin's internal states.

`.validConsent()` returns true if none of the following situations occur:

- consent is missing (e.g. user has not yet made a choice)
- revision numbers don't match
- the plugin's cookie does not exist/has expired
- the plugin's cookie is structurally not valid (e.g. empty)