### PR TITLE
fix: add support for all elements with data role to be used as settings

### DIFF
--- a/src/cookieconsent.js
+++ b/src/cookieconsent.js
@@ -285,7 +285,7 @@
              * @returns {NodeListOf<Element>}
              */
             function _getElements(data_role){
-                return (elem || document).querySelectorAll('a[data-cc="' + data_role + '"], button[data-cc="' + data_role + '"]');
+                return (elem || document).querySelectorAll('[data-cc="' + data_role + '"]');
             }
 
             /**


### PR DESCRIPTION
Hello, I have fixed this selector to support all elements, not only usual anchor and button. We would like to use c-settings on custom element (web component), which has different selector.