### PR TITLE
Fix #309

### DIFF
--- a/src/cookieconsent.js
+++ b/src/cookieconsent.js
@@ -1279,7 +1279,7 @@
 
             if (_config.auto_language === 'browser') {
                 return _getValidatedLanguage(_getBrowserLang(), languages);
-            } else if (_config.auto_language === 'document') {
+            } else if (_config.auto_language === 'document' && document.documentElement.lang) {
                 return _getValidatedLanguage(document.documentElement.lang, languages);
             } else {
                 if (typeof requested_language === 'string') {


### PR DESCRIPTION
Default to `user_config.current_lang` before defaulting to `_config.current_lang` when `auto_language: document` and document lang is not defined