### PR TITLE
Adds optional settings for privacy policy and imprint links within the modal

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,19 +4,22 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 ![Size](https://img.shields.io/github/size/orestbida/cookieconsent/dist/cookieconsent.js)
 [![Stable version](https://img.shields.io/github/v/release/orestbida/cookieconsent)](https://github.com/orestbida/cookieconsent/releases)
+
 </div>
 <div align="center" style="text-align: center; max-width: 770px; margin: 0 auto;">
 
-A __lightweight__ & __gdpr compliant__ cookie consent plugin written in plain javascript.
+A **lightweight** & **gdpr compliant** cookie consent plugin written in plain javascript.
 
 </div>
 <div style="padding-top: .6em;">
 
 ![Cookie Consent cover](demo/assets/cover.png)
 ![Cookie Consent cover](demo/assets/features.png)
+
 </div>
 
 ## Table of contents
+
 - [Table of contents](#table-of-contents)
 - [Key features](#key-features)
 - [Installation & Usage](#installation--usage)
@@ -33,17 +36,19 @@ A __lightweight__ & __gdpr compliant__ cookie consent plugin written in plain ja
 - [License](#license)
 
 ## Key features
-- __Lightweight__
-- __Cross-browser__ support (IE8+)
-- __Standalone__ (no external dependencies needed)
-- __GDPR compliant__
-- __Support for multi language__
-- __[WAI-ARIA](https://developer.mozilla.org/en-US/docs/Learn/Accessibility/WAI-ARIA_basics) compliant__
-- Allows you to __define different cookie categories with opt in/out toggle__
-- Allows you to __define custom cookie tables__ to specify the cookies you use
+
+- **Lightweight**
+- **Cross-browser** support (IE8+)
+- **Standalone** (no external dependencies needed)
+- **GDPR compliant**
+- **Support for multi language**
+- **[WAI-ARIA](https://developer.mozilla.org/en-US/docs/Learn/Accessibility/WAI-ARIA_basics) compliant**
+- Allows you to **define different cookie categories with opt in/out toggle**
+- Allows you to **define custom cookie tables** to specify the cookies you use
 
 ## Installation & Usage
-1. Download the [latest release](https://github.com/orestbida/cookieconsent/releases/latest) or use via CDN or [NPM](https://www.npmjs.com/package/vanilla-cookieconsent)
+
+1.  Download the [latest release](https://github.com/orestbida/cookieconsent/releases/latest) or use via CDN or [NPM](https://www.npmjs.com/package/vanilla-cookieconsent)
 
     ```bash
     # CDN links
@@ -58,38 +63,47 @@ A __lightweight__ & __gdpr compliant__ cookie consent plugin written in plain ja
     yarn add vanilla-cookieconsent
     ```
 
-1. Import the plugin: add a `script` tag pointing to `cookieconsent.js`
+1.  Import the plugin: add a `script` tag pointing to `cookieconsent.js`
+
     ```html
     <html>
-        <head>
-            <!-- head content -->
-            <!-- Deferred CSS loading (recommended) -->
-            <link rel="stylesheet" href="<path-to-cookieconsent.css>" media="print" onload="this.media='all'">
-        </head>
-        <body>
-            <!-- body content -->
-            <script defer src="<path-to-cookieconsent.js>"></script>
-        </body>
+      <head>
+        <!-- head content -->
+        <!-- Deferred CSS loading (recommended) -->
+        <link
+          rel="stylesheet"
+          href="<path-to-cookieconsent.css>"
+          media="print"
+          onload="this.media='all'"
+        />
+      </head>
+      <body>
+        <!-- body content -->
+        <script defer src="<path-to-cookieconsent.js>"></script>
+      </body>
     </html>
     ```
+
     <span>Note: replace `<path-to-cookieconsent.js>` and `<path-to-cookieconsent.css>` with valid paths!</span>
     <br>
 
-3. Configure and run
-    -   <details><summary>As external script</summary>
-        <p>
+1.  Configure and run
 
-        - Create a `.js` file (e.g. `cookieconsent-init.js`) and import it in your html page
+    - <details><summary>As external script</summary>
+      <p>
 
-            ```html
-            <body>
-                <!-- body content ... -->
-                <script defer src="<path-to-cookieconsent.js>"></script>
-                <script defer src="<path-to-cookieconsent-init.js>"></script>
-            <body>
-            ```
+      - Create a `.js` file (e.g. `cookieconsent-init.js`) and import it in your html page
 
-        - Configure the plugin inside `cookieconsent-init.js`
+        ```html
+        <body>
+          <!-- body content ... -->
+          <script defer src="<path-to-cookieconsent.js>"></script>
+          <script defer src="<path-to-cookieconsent-init.js>"></script>
+          <body></body>
+        </body>
+        ```
+
+      - Configure the plugin inside `cookieconsent-init.js`
 
             ```javascript
             // obtain plugin
@@ -141,7 +155,15 @@ A __lightweight__ & __gdpr compliant__ cookie consent plugin written in plain ja
                             secondary_btn: {
                                 text: 'Reject all',
                                 role: 'accept_necessary'        // 'settings' or 'accept_necessary'
-                            }
+                            },
+                            imprint_link: {                     // 'optional to display imprint link on the modal or remove it'
+                                text: "imprint",
+                                url: "/imprint.html",
+                            },
+                            privacy_policy_link: {              // 'optional to display privacy policy link on the modal or remove it'
+                                text: "privacy policy",
+                                url: "/privacy.html",
+                            },
                         },
                         settings_modal: {
                             title: 'Cookie preferences',
@@ -208,194 +230,215 @@ A __lightweight__ & __gdpr compliant__ cookie consent plugin written in plain ja
                 }
             });
             ```
+
         </p>
         </details>
-    -   <details><summary>As inline script</summary>
-        <p>
 
-        ```html
-        <body>
-            <!-- body content ... -->
-            <script defer src="<path-to-cookieconsent.js>"></script>
+    - <details><summary>As inline script</summary>
+          <p>
 
-            <!-- Inline script -->
-            <script>
-                window.addEventListener('load', function(){
+          ```html
+          <body>
+              <!-- body content ... -->
+              <script defer src="<path-to-cookieconsent.js>"></script>
 
-                    // obtain plugin
-                    var cc = initCookieConsent();
+              <!-- Inline script -->
+              <script>
+                  window.addEventListener('load', function(){
 
-                    // run plugin with your configuration
-                    cc.run({
-                        current_lang: 'en',
-                        autoclear_cookies: true,                   // default: false
-                        page_scripts: true,                        // default: false
+                      // obtain plugin
+                      var cc = initCookieConsent();
 
-                        // mode: 'opt-in'                          // default: 'opt-in'; value: 'opt-in' or 'opt-out'
-                        // delay: 0,                               // default: 0
-                        // auto_language: '',                      // default: null; could also be 'browser' or 'document'
-                        // autorun: true,                          // default: true
-                        // force_consent: false,                   // default: false
-                        // hide_from_bots: false,                  // default: false
-                        // remove_cookie_tables: false             // default: false
-                        // cookie_name: 'cc_cookie',               // default: 'cc_cookie'
-                        // cookie_expiration: 182,                 // default: 182 (days)
-                        // cookie_necessary_only_expiration: 182   // default: disabled
-                        // cookie_domain: location.hostname,       // default: current domain
-                        // cookie_path: '/',                       // default: root
-                        // cookie_same_site: 'Lax',                // default: 'Lax'
-                        // use_rfc_cookie: false,                  // default: false
-                        // revision: 0,                            // default: 0
+                      // run plugin with your configuration
+                      cc.run({
+                          current_lang: 'en',
+                          autoclear_cookies: true,                   // default: false
+                          page_scripts: true,                        // default: false
 
-                        onFirstAction: function(user_preferences, cookie){
-                            // callback triggered only once on the first accept/reject action
-                        },
+                          // mode: 'opt-in'                          // default: 'opt-in'; value: 'opt-in' or 'opt-out'
+                          // delay: 0,                               // default: 0
+                          // auto_language: '',                      // default: null; could also be 'browser' or 'document'
+                          // autorun: true,                          // default: true
+                          // force_consent: false,                   // default: false
+                          // hide_from_bots: false,                  // default: false
+                          // remove_cookie_tables: false             // default: false
+                          // cookie_name: 'cc_cookie',               // default: 'cc_cookie'
+                          // cookie_expiration: 182,                 // default: 182 (days)
+                          // cookie_necessary_only_expiration: 182   // default: disabled
+                          // cookie_domain: location.hostname,       // default: current domain
+                          // cookie_path: '/',                       // default: root
+                          // cookie_same_site: 'Lax',                // default: 'Lax'
+                          // use_rfc_cookie: false,                  // default: false
+                          // revision: 0,                            // default: 0
 
-                        onAccept: function (cookie) {
-                            // callback triggered on the first accept/reject action, and after each page load
-                        },
+                          onFirstAction: function(user_preferences, cookie){
+                              // callback triggered only once on the first accept/reject action
+                          },
 
-                        onChange: function (cookie, changed_categories) {
-                            // callback triggered when user changes preferences after consent has already been given
-                        },
+                          onAccept: function (cookie) {
+                              // callback triggered on the first accept/reject action, and after each page load
+                          },
 
-                        languages: {
-                            'en': {
-                                consent_modal: {
-                                    title: 'We use cookies!',
-                                    description: 'Hi, this website uses essential cookies to ensure its proper operation and tracking cookies to understand how you interact with it. The latter will be set only after consent. <button type="button" data-cc="c-settings" class="cc-link">Let me choose</button>',
-                                    primary_btn: {
-                                        text: 'Accept all',
-                                        role: 'accept_all'              // 'accept_selected' or 'accept_all'
-                                    },
-                                    secondary_btn: {
-                                        text: 'Reject all',
-                                        role: 'accept_necessary'        // 'settings' or 'accept_necessary'
-                                    }
-                                },
-                                settings_modal: {
-                                    title: 'Cookie preferences',
-                                    save_settings_btn: 'Save settings',
-                                    accept_all_btn: 'Accept all',
-                                    reject_all_btn: 'Reject all',
-                                    close_btn_label: 'Close',
-                                    cookie_table_headers: [
-                                        {col1: 'Name'},
-                                        {col2: 'Domain'},
-                                        {col3: 'Expiration'},
-                                        {col4: 'Description'}
-                                    ],
-                                    blocks: [
-                                        {
-                                            title: 'Cookie usage 📢',
-                                            description: 'I use cookies to ensure the basic functionalities of the website and to enhance your online experience. You can choose for each category to opt-in/out whenever you want. For more details relative to cookies and other sensitive data, please read the full <a href="#" class="cc-link">privacy policy</a>.'
-                                        }, {
-                                            title: 'Strictly necessary cookies',
-                                            description: 'These cookies are essential for the proper functioning of my website. Without these cookies, the website would not work properly',
-                                            toggle: {
-                                                value: 'necessary',
-                                                enabled: true,
-                                                readonly: true          // cookie categories with readonly=true are all treated as "necessary cookies"
-                                            }
-                                        }, {
-                                            title: 'Performance and Analytics cookies',
-                                            description: 'These cookies allow the website to remember the choices you have made in the past',
-                                            toggle: {
-                                                value: 'analytics',     // your cookie category
-                                                enabled: false,
-                                                readonly: false
-                                            },
-                                            cookie_table: [             // list of all expected cookies
-                                                {
-                                                    col1: '^_ga',       // match all cookies starting with "_ga"
-                                                    col2: 'google.com',
-                                                    col3: '2 years',
-                                                    col4: 'description ...',
-                                                    is_regex: true
-                                                },
-                                                {
-                                                    col1: '_gid',
-                                                    col2: 'google.com',
-                                                    col3: '1 day',
-                                                    col4: 'description ...',
-                                                }
-                                            ]
-                                        }, {
-                                            title: 'Advertisement and Targeting cookies',
-                                            description: 'These cookies collect information about how you use the website, which pages you visited and which links you clicked on. All of the data is anonymized and cannot be used to identify you',
-                                            toggle: {
-                                                value: 'targeting',
-                                                enabled: false,
-                                                readonly: false
-                                            }
-                                        }, {
-                                            title: 'More information',
-                                            description: 'For any queries in relation to our policy on cookies and your choices, please <a class="cc-link" href="#yourcontactpage">contact us</a>.',
-                                        }
-                                    ]
-                                }
-                            }
-                        }
-                    });
-                });
-            </script>
-        <body>
-        ```
-      </p>
-    </details>
-    <br>
+                          onChange: function (cookie, changed_categories) {
+                              // callback triggered when user changes preferences after consent has already been given
+                          },
+
+                          languages: {
+                              'en': {
+                                  consent_modal: {
+                                      title: 'We use cookies!',
+                                      description: 'Hi, this website uses essential cookies to ensure its proper operation and tracking cookies to understand how you interact with it. The latter will be set only after consent. <button type="button" data-cc="c-settings" class="cc-link">Let me choose</button>',
+                                      primary_btn: {
+                                          text: 'Accept all',
+                                          role: 'accept_all'              // 'accept_selected' or 'accept_all'
+                                      },
+                                      secondary_btn: {
+                                          text: 'Reject all',
+                                          role: 'accept_necessary'        // 'settings' or 'accept_necessary'
+                                      },
+                                      imprint_link: {                     // 'optional to display imprint link on the modal or remove it'
+                                          text: "imprint",
+                                          url: "/imprint.html",
+                                      },
+                                      privacy_policy_link: {              // 'optional to display privacy policy link on the modal or remove it'
+                                          text: "privacy policy",
+                                          url: "/privacy.html",
+                                      },
+                                  },
+                                  settings_modal: {
+                                      title: 'Cookie preferences',
+                                      save_settings_btn: 'Save settings',
+                                      accept_all_btn: 'Accept all',
+                                      reject_all_btn: 'Reject all',
+                                      close_btn_label: 'Close',
+                                      cookie_table_headers: [
+                                          {col1: 'Name'},
+                                          {col2: 'Domain'},
+                                          {col3: 'Expiration'},
+                                          {col4: 'Description'}
+                                      ],
+                                      blocks: [
+                                          {
+                                              title: 'Cookie usage 📢',
+                                              description: 'I use cookies to ensure the basic functionalities of the website and to enhance your online experience. You can choose for each category to opt-in/out whenever you want. For more details relative to cookies and other sensitive data, please read the full <a href="#" class="cc-link">privacy policy</a>.'
+                                          }, {
+                                              title: 'Strictly necessary cookies',
+                                              description: 'These cookies are essential for the proper functioning of my website. Without these cookies, the website would not work properly',
+                                              toggle: {
+                                                  value: 'necessary',
+                                                  enabled: true,
+                                                  readonly: true          // cookie categories with readonly=true are all treated as "necessary cookies"
+                                              }
+                                          }, {
+                                              title: 'Performance and Analytics cookies',
+                                              description: 'These cookies allow the website to remember the choices you have made in the past',
+                                              toggle: {
+                                                  value: 'analytics',     // your cookie category
+                                                  enabled: false,
+                                                  readonly: false
+                                              },
+                                              cookie_table: [             // list of all expected cookies
+                                                  {
+                                                      col1: '^_ga',       // match all cookies starting with "_ga"
+                                                      col2: 'google.com',
+                                                      col3: '2 years',
+                                                      col4: 'description ...',
+                                                      is_regex: true
+                                                  },
+                                                  {
+                                                      col1: '_gid',
+                                                      col2: 'google.com',
+                                                      col3: '1 day',
+                                                      col4: 'description ...',
+                                                  }
+                                              ]
+                                          }, {
+                                              title: 'Advertisement and Targeting cookies',
+                                              description: 'These cookies collect information about how you use the website, which pages you visited and which links you clicked on. All of the data is anonymized and cannot be used to identify you',
+                                              toggle: {
+                                                  value: 'targeting',
+                                                  enabled: false,
+                                                  readonly: false
+                                              }
+                                          }, {
+                                              title: 'More information',
+                                              description: 'For any queries in relation to our policy on cookies and your choices, please <a class="cc-link" href="#yourcontactpage">contact us</a>.',
+                                          }
+                                      ]
+                                  }
+                              }
+                          }
+                      });
+                  });
+              </script>
+          <body>
+          ```
+
+        </p>
+      </details>
+      <br>
 
 ## Layout options & customization
+
 You can change the color scheme with css variables inside cookieconsent.css. You can also change some basic layout options via the `gui_options` inside the config. object; example:
 
 ```javascript
 cookieconsent.run({
-    // ...
-    gui_options: {
-        consent_modal: {
-            layout: 'cloud',               // box/cloud/bar
-            position: 'bottom center',     // bottom/middle/top + left/right/center
-            transition: 'slide',           // zoom/slide
-            swap_buttons: false            // enable to invert buttons
-        },
-        settings_modal: {
-            layout: 'box',                 // box/bar
-            // position: 'left',           // left/right
-            transition: 'slide'            // zoom/slide
-        }
-    }
-    //...
+  // ...
+  gui_options: {
+    consent_modal: {
+      layout: "cloud", // box/cloud/bar
+      position: "bottom center", // bottom/middle/top + left/right/center
+      transition: "slide", // zoom/slide
+      swap_buttons: false, // enable to invert buttons
+    },
+    settings_modal: {
+      layout: "box", // box/bar
+      // position: 'left',           // left/right
+      transition: "slide", // zoom/slide
+    },
+  },
+  //...
 });
 ```
+
 <i>Default layout is `box` and default transition is `zoom`.</i>
 
 <br>
 
 ## How to block/manage scripts
+
 You can manage any script (inline or external) via the `page_scripts` option:
 
 1. Enable page scripts management:
 
-    ```javascript
-    cookieconsent.run({
-        // ...
-        page_scripts: true
-        // ...
-    });
-    ```
+   ```javascript
+   cookieconsent.run({
+     // ...
+     page_scripts: true,
+     // ...
+   });
+   ```
+
 2. Set `type="text/plain"` and `data-cookiecategory="<category>"` to any `script` tag you want to manage:
 
-    ```html
-    <script type="text/plain" data-cookiecategory="analytics" src="analytics.js" defer></script>
+   ```html
+   <script
+     type="text/plain"
+     data-cookiecategory="analytics"
+     src="analytics.js"
+     defer
+   ></script>
 
-    <script type="text/plain" data-cookiecategory="ads">
-        console.log('"ads" category accepted');
-    </script>
-    ```
-    <i>Note: `data-cookiecategory` must be a valid category defined inside the configuration object</i>
+   <script type="text/plain" data-cookiecategory="ads">
+     console.log('"ads" category accepted');
+   </script>
+   ```
 
+   <i>Note: `data-cookiecategory` must be a valid category defined inside the configuration object</i>
 
 ## API methods
+
 After getting the plugin like so:
 
 ```javascript
@@ -411,207 +454,246 @@ the following methods are available:
 - cookieconsent`.hideSettings()`
 
 Additional methods for an easier management of your scripts and cookie settings (expand them to see usage example):
+
 - <details><summary>cookieconsent<code>.accept(&lt;accepted_categories&gt;, &lt;optional_rejected_categories&gt;)</code> [v2.5.0+]</summary>
     <p>
 
-    - accepted_categories: `string` or `string[]`
-    - rejected_categories: `string[]` - optional
+  - accepted_categories: `string` or `string[]`
+  - rejected_categories: `string[]` - optional
 
     <br>
 
-    Note: **all categories marked as `readonly` will ALWAYS be enabled/accepted regardless of the categories provided inside the `.accept()` API call.**
+  Note: **all categories marked as `readonly` will ALWAYS be enabled/accepted regardless of the categories provided inside the `.accept()` API call.**
 
-    Examples:
+  Examples:
 
-    ```javascript
-    cookieconsent.accept('all');                // accept all categories
-    cookieconsent.accept([]);                   // accept none (reject all)
-    cookieconsent.accept('analytics');          // accept only analytics category
-    cookieconsent.accept(['cat_1', 'cat_2']);   // accept only these 2 categories
-    cookieconsent.accept();                     // accept all currently selected categories inside modal
+  ```javascript
+  cookieconsent.accept("all"); // accept all categories
+  cookieconsent.accept([]); // accept none (reject all)
+  cookieconsent.accept("analytics"); // accept only analytics category
+  cookieconsent.accept(["cat_1", "cat_2"]); // accept only these 2 categories
+  cookieconsent.accept(); // accept all currently selected categories inside modal
 
-    cookieconsent.accept('all', ['analytics']); // accept all except "analytics" category
-    cookieconsent.accept('all', ['cat_1', 'cat_2']); // accept all except these 2 categories
-    ```
+  cookieconsent.accept("all", ["analytics"]); // accept all except "analytics" category
+  cookieconsent.accept("all", ["cat_1", "cat_2"]); // accept all except these 2 categories
+  ```
 
-    How to later reject a specific category (cookieconsent already accepted)? Same as above:
+  How to later reject a specific category (cookieconsent already accepted)? Same as above:
 
-    ```javascript
-    cookieconsent.accept('all', ['targeting']);     // opt out of targeting category
-    ```
+  ```javascript
+  cookieconsent.accept("all", ["targeting"]); // opt out of targeting category
+  ```
+
     </p>
     </details>
+
 - <details><summary>cookieconsent<code>.allowedCategory(&lt;category_name&gt;)</code></summary>
     <p>
 
-    <b>Note:</b> there are no default cookie categories, you create them!
+  <b>Note:</b> there are no default cookie categories, you create them!
 
+  A cookie category corresponds to the string of the <code>value</code> property inside the <code>toggle</code> object:
 
-    A cookie category corresponds to the string of the <code>value</code> property inside the <code>toggle</code> object:
+  ```javascript
+  // ...
+  toggle: {
+      value: 'analytics',     // cookie category
+      enabled: false,         // default status
+      readonly: false         // allow to enable/disable
+      // reload: 'on_disable',   // allows to reload page when the current cookie category is deselected
+  }
+  // ...
+  ```
 
-    ```javascript
-    // ...
-    toggle: {
-        value: 'analytics',     // cookie category
-        enabled: false,         // default status
-        readonly: false         // allow to enable/disable
-        // reload: 'on_disable',   // allows to reload page when the current cookie category is deselected
-    }
-    // ...
-    ```
+  Example:
 
-    Example:
-    ```javascript
-    // Check if user accepts cookie consent with analytics category enabled
-    if (!cookieconsent.allowedCategory('analytics')) {
-        // yoo, you might want to load analytics.js ...
-    };
-    ```
+  ```javascript
+  // Check if user accepts cookie consent with analytics category enabled
+  if (!cookieconsent.allowedCategory("analytics")) {
+    // yoo, you might want to load analytics.js ...
+  }
+  ```
+
     </p>
     </details>
+
 - <details><summary>cookieconsent<code>.validCookie(&lt;cookie_name&gt;)</code></summary>
     <p>
 
-    If cookie exists and has non empty (<code>''</code>) value => return <code>true</code>, otherwise <code>false</code>.
+  If cookie exists and has non empty (<code>''</code>) value => return <code>true</code>, otherwise <code>false</code>.
 
-    ```javascript
-    // Example: check if '_gid' cookie is set
-    if (!cookieconsent.validCookie('_gid')) {
-        // yoo, _gid cookie is not set, do something ...
-    };
-    ```
+  ```javascript
+  // Example: check if '_gid' cookie is set
+  if (!cookieconsent.validCookie("_gid")) {
+    // yoo, _gid cookie is not set, do something ...
+  }
+  ```
+
     </p>
     </details>
+
 - <details><summary>cookieconsent<code>.eraseCookies(&lt;cookie_names&gt;, &lt;optional_path&gt;, &lt;optional_domains&gt;)</code> [v2.5.0+]</summary>
     <p>
 
-    - cookie_names: `string[]`
-    - path: `string` - optional
-    - domains: `string[]` - optional
+  - cookie_names: `string[]`
+  - path: `string` - optional
+  - domains: `string[]` - optional
 
     <br>
 
-    Examples:
+  Examples:
 
-    ```javascript
-    cookieconsent.eraseCookies(['cc_cookies']);             // erase "cc_cookie" if it exists
-    cookieconsent.eraseCookies(['cookie1', 'cookie2']);     // erase these 2 cookies
+  ```javascript
+  cookieconsent.eraseCookies(["cc_cookies"]); // erase "cc_cookie" if it exists
+  cookieconsent.eraseCookies(["cookie1", "cookie2"]); // erase these 2 cookies
 
-    cookieconsent.eraseCookies(['cc_cookie'], "/demo");
-    cookieconsent.eraseCookies(['cc_cookie'], "/demo", [location.hostname]);
-    ```
+  cookieconsent.eraseCookies(["cc_cookie"], "/demo");
+  cookieconsent.eraseCookies(["cc_cookie"], "/demo", [location.hostname]);
+  ```
+
     </p>
     </details>
+
 - <details><summary>cookieconsent<code>.loadScript(&lt;path&gt;, &lt;callback_function&gt;, &lt;optional_custom_attributes&gt;)</code></summary>
     <p>
 
-    Basic example:
+  Basic example:
 
-    ```javascript
-    cookieconsent.loadScript('https://www.google-analytics.com/analytics.js', function(){
-        // Script loaded, do something
-    });
-    ```
-    How to load scripts with custom attributes:
-    ```javascript
-    cookieconsent.loadScript('https://www.google-analytics.com/analytics.js', function(){
-        // Script loaded, do something
-    }, [
-        {name: 'id', value: 'ga_id'},
-        {name: 'another-attribute', value: 'value'}
-    ]);
-    ```
+  ```javascript
+  cookieconsent.loadScript(
+    "https://www.google-analytics.com/analytics.js",
+    function () {
+      // Script loaded, do something
+    }
+  );
+  ```
+
+  How to load scripts with custom attributes:
+
+  ```javascript
+  cookieconsent.loadScript(
+    "https://www.google-analytics.com/analytics.js",
+    function () {
+      // Script loaded, do something
+    },
+    [
+      { name: "id", value: "ga_id" },
+      { name: "another-attribute", value: "value" },
+    ]
+  );
+  ```
+
     </p>
     </details>
+
 - <details><summary>cookieconsent<code>.set(&lt;field&gt;, &lt;object&gt;)</code> [v2.6.0+]</summary>
     <p>
 
-    The `.set()` method allows you to set the following values:
-    - **data** (used to save custom data inside the plugin's cookie)
-    - **revision**
+  The `.set()` method allows you to set the following values:
+
+  - **data** (used to save custom data inside the plugin's cookie)
+  - **revision**
 
     <br>
 
-    How to save custom `data`:
-    ```javascript
-    // Set cookie's "data" field to whatever the value of the `value` prop. is
-    cookieconsent.set('data', {value: {id: 21, country: "italy"}});
+  How to save custom `data`:
 
-    // Only add/update the specified props.
-    cookieconsent.set('data', {value: {id: 22, new_prop: 'new prop value'}, mode: 'update'});
-    ```
+  ```javascript
+  // Set cookie's "data" field to whatever the value of the `value` prop. is
+  cookieconsent.set("data", { value: { id: 21, country: "italy" } });
+
+  // Only add/update the specified props.
+  cookieconsent.set("data", {
+    value: { id: 22, new_prop: "new prop value" },
+    mode: "update",
+  });
+  ```
+
     </p>
     </details>
+
 - <details><summary>cookieconsent<code>.get(&lt;field&gt;)</code> [v2.6.0+]</summary>
     <p>
 
-    The `.get()` method allows you to retrieve any of the fields inside the plugin's cookie:
-    ```javascript
-    cookieconsent.get('level');     // retrieve all accepted categories (if cookie exists)
-    cookieconsent.get('data');      // retrieve custom data (if cookie exists)
-    cookieconsent.get('revision');  // retrieve revision number (if cookie exists)
-    ```
+  The `.get()` method allows you to retrieve any of the fields inside the plugin's cookie:
+
+  ```javascript
+  cookieconsent.get("level"); // retrieve all accepted categories (if cookie exists)
+  cookieconsent.get("data"); // retrieve custom data (if cookie exists)
+  cookieconsent.get("revision"); // retrieve revision number (if cookie exists)
+  ```
+
     </p>
     </details>
+
 - <details><summary>cookieconsent<code>.getConfig(&lt;field&gt;)</code> [v2.7.0+]</summary>
     <p>
 
-    The `.getConfig()` method allows you to read configuration options from the current instance:
-    ```javascript
-    cookieconsent.getConfig('current_lang');        // get currently used language
-    cookieconsent.getConfig('cookie_expiration');   // get configured cookie expiration
-    // ...
-    ```
+  The `.getConfig()` method allows you to read configuration options from the current instance:
+
+  ```javascript
+  cookieconsent.getConfig("current_lang"); // get currently used language
+  cookieconsent.getConfig("cookie_expiration"); // get configured cookie expiration
+  // ...
+  ```
+
     </p>
     </details>
+
 - <details><summary>cookieconsent<code>.getUserPreferences()</code> [v2.7.0+]</summary>
     <p>
 
-    The `.getUserPreferences()` returns the following object (for analytics/logging purposes):
-    ```javascript
-    {
-        accept_type: string,            // 'all', 'necessary', 'custom'
-        accepted_categories: string[],  // e.g. ['necessary', 'analytics']
-        rejected_categories: string[]   // e.g. ['ads']
-    }
-    ```
+  The `.getUserPreferences()` returns the following object (for analytics/logging purposes):
+
+  ```javascript
+  {
+      accept_type: string,            // 'all', 'necessary', 'custom'
+      accepted_categories: string[],  // e.g. ['necessary', 'analytics']
+      rejected_categories: string[]   // e.g. ['ads']
+  }
+  ```
+
     </p>
     </details>
+
 - <details><summary>cookieconsent<code>.updateScripts()</code> [v2.7.0+]</summary>
     <p>
 
-    This method allows the plugin to manage dynamically added/injected scripts that have been loaded after the plugin's execution.
+  This method allows the plugin to manage dynamically added/injected scripts that have been loaded after the plugin's execution.
 
-    E.g. dynamic content generated by server side languages like php, node, ruby ...
+  E.g. dynamic content generated by server side languages like php, node, ruby ...
     </p>
     </details>
+
 - <details><summary>cookieconsent<code>.updateLanguage(&lt;language&gt;, &lt;force_update&gt;)</code> [v2.8.0+]</summary>
     <p>
 
-    Use this method to change modal's language dynamically (without page reload).
+  Use this method to change modal's language dynamically (without page reload).
 
-    - language: `string`
-    - force_update: `boolean` - optional
-
-    <br>
-
-    Example:
-    ```javascript
-    cookieconsent.updateLanguage('it');
-    ```
-
-    Note: language will change only if it is valid (already defined) and different from the current language!
+  - language: `string`
+  - force_update: `boolean` - optional
 
     <br>
 
-    You can also forcefully update the modals (useful if you dynamically change the content of the modals). Example:
-    ```javascript
-    // Change content: e.g. modify modal title
-    cookieconsent.getConfig('languages').en.consent_modal.title = 'New title';
+  Example:
 
-    // Update changes
-    cookieconsent.updateLanguage('en', true);
-    ```
+  ```javascript
+  cookieconsent.updateLanguage("it");
+  ```
+
+  Note: language will change only if it is valid (already defined) and different from the current language!
+
+    <br>
+
+  You can also forcefully update the modals (useful if you dynamically change the content of the modals). Example:
+
+  ```javascript
+  // Change content: e.g. modify modal title
+  cookieconsent.getConfig("languages").en.consent_modal.title = "New title";
+
+  // Update changes
+  cookieconsent.updateLanguage("en", true);
+  ```
 
     </p>
     </details>
@@ -619,102 +701,126 @@ Additional methods for an easier management of your scripts and cookie settings 
 <br>
 
 ## Available `data-cc` actions
+
 Any button (or link) can use the custom `data-cc` attribute to perform a few actions without manually invoking the api methods.
 
 Valid values:
+
 - `c-settings`: show settings modal
 - `accept-all`: accept all categories
 - `accept-necessary`: accept only categories marked as necessary/readonly (reject all)
 - `accept-custom`: accept currently selected categories inside the settings modal
 
 Examples:
+
 ```html
 <button type="button" data-cc="c-settings">Show cookie settings</button>
 <button type="button" data-cc="accept-all">Accept all cookies</button>
 ```
+
 <br>
 
 ## Available callbacks
+
 The following functions have to be defined inside the configuration object passed to the `.run()` method.
 
 - <details><summary><code>onAccept</code></summary>
     <p>
 
-    This function will be executed:
-    - at the first moment that consent is given (just like `onFirstAction`)
-    - after every page load, if consent (accept or "reject" action) has already been given
+  This function will be executed:
+
+  - at the first moment that consent is given (just like `onFirstAction`)
+  - after every page load, if consent (accept or "reject" action) has already been given
 
     <br>
 
-    parameters:
-    - `cookie`: contains the current value of the cookie
+  parameters:
+
+  - `cookie`: contains the current value of the cookie
 
     <br>
 
-    example:
-    ```javascript
-    //...
-    cc.run({
-        // ...
-        onAccept: function(cookie){
-            // load somescript, google analytics ...
-        },
-        // ...
-    });
-    ```
+  example:
+
+  ```javascript
+  //...
+  cc.run({
+    // ...
+    onAccept: function (cookie) {
+      // load somescript, google analytics ...
+    },
+    // ...
+  });
+  ```
+
     </p>
     </details>
+
 - <details><summary><code>onChange</code></summary>
     <p>
 
-    This function will be executed (only if consent has already been given):
-    - when user changes his preferences (accepts/rejects a cookie category)
+  This function will be executed (only if consent has already been given):
+
+  - when user changes his preferences (accepts/rejects a cookie category)
 
     <br>
 
-    parameters:
-    - `cookie`: contains the current value of the cookie
-    - `changed_categories`: array of categories whose state (accepted/rejected) just changed
+  parameters:
+
+  - `cookie`: contains the current value of the cookie
+  - `changed_categories`: array of categories whose state (accepted/rejected) just changed
 
     <br>
 
-    example:
-    ```javascript
-    //...
-    cc.run({
-        // ...
-        onChange: function(cookie, changed_categories){
-            // cleanup logic ... (e.g. disable gtm if analytics category is disabled)
-        },
-        // ...
-    });
-    ```
+  example:
+
+  ```javascript
+  //...
+  cc.run({
+    // ...
+    onChange: function (cookie, changed_categories) {
+      // cleanup logic ... (e.g. disable gtm if analytics category is disabled)
+    },
+    // ...
+  });
+  ```
+
     </p>
     </details>
+
 - <details><summary><code>onFirstAction</code> [v2.7.0+]</summary>
     <p>
 
-    This function will be executed only once, when the user takes the first action (accept/reject).
+  This function will be executed only once, when the user takes the first action (accept/reject).
 
-    parameters:
-    - `user_preferences`: contains the same data provided by the `.getUserPreferences()` API
-    - `cookie`: contains the current value of the cookie
+  parameters:
+
+  - `user_preferences`: contains the same data provided by the `.getUserPreferences()` API
+  - `cookie`: contains the current value of the cookie
 
     <br>
 
-    example:
-    ```javascript
-    //...
-    cc.run({
-        // ...
-        onFirstAction: function(user_preferences, cookie){
-            console.log('User accept type:', user_preferences.accept_type);
-            console.log('User accepted these categories', user_preferences.accepted_categories)
-            console.log('User reject these categories:', user_preferences.rejected_categories);
-        },
-        // ...
-    });
-    ```
+  example:
+
+  ```javascript
+  //...
+  cc.run({
+    // ...
+    onFirstAction: function (user_preferences, cookie) {
+      console.log("User accept type:", user_preferences.accept_type);
+      console.log(
+        "User accepted these categories",
+        user_preferences.accepted_categories
+      );
+      console.log(
+        "User reject these categories:",
+        user_preferences.rejected_categories
+      );
+    },
+    // ...
+  });
+  ```
+
     </p>
     </details>
 
@@ -723,157 +829,173 @@ The following functions have to be defined inside the configuration object passe
 ### All configuration options
 
 Below a table which sums up all of the available options (must be passed to the .run() method).
-| Option              	| Type     	| Default 	| Description                                                                                                                       |
-|---------------------	|----------	|---------	|---------------------------------------------------------------------------------------------------------------------------------- |
-| `autorun`           	| boolean  	| true    	| If enabled, show the cookie consent as soon as possible (otherwise you need to manually call the `.show()` method)                |
-| `delay`             	| number   	| 0       	| Number of `milliseconds` before showing the consent-modal                                                                         |
-| `mode`             	| string   	| 'opt-in'  |Accepted values: <br> - `opt-in`: scripts will not run unless consent is given (gdpr compliant) <br> - `opt-out`: scripts — that have categories set as `enabled` by default — will run without consent, until an explicit choice is made                                                 |
-| `cookie_expiration` 	| number   	| 182     	| Number of days before the cookie expires (182 days = 6 months)                                                                    |
-| `cookie_necessary_only_expiration` 	| number   	| -     	| Specify if you want to set a different number of days - before the cookie expires - when the user accepts only the necessary categories                                                |
-| `cookie_path` 	    | string   	| "/"     	| Path where the cookie will be set                                                                                                 |
-| `cookie_domain` 	    | string   	| location.hostname | Specify your domain (will be grabbed by default) or a subdomain                                                           |
-| `cookie_same_site` 	| string   	| "Lax"     | SameSite attribute                                                           |
-| `use_rfc_cookie` 	    | boolean   | false     | Enable if you want the value of the cookie to be rfc compliant                                            |
-| `force_consent`       | boolean   | false     | Enable if you want to block page navigation until user action (check [faq](#faq) for a proper implementation) |
-| `revision`            | number  	| 0   	    | Specify this option to enable revisions. [Check below](#how-to-enablemanage-revisions) for a proper usage |
-| `current_lang`      	| string   	| -       	| Specify one of the languages you have defined (can also be dynamic): `'en'`, `'de'` ...                                           |
-| `auto_language`     	| string  	| null  	| Language auto-detection strategy. Null to disable (default), `"browser"` to get user's browser language or `"document"` to read value from `<html lang="...">` of current page. If language is not defined => use specified `current_lang` |
-| `autoclear_cookies` 	| boolean  	| false   	| Enable if you want to automatically delete cookies when user opts-out of a specific category inside cookie settings               |
-| `page_scripts` 	    | boolean  	| false   	| Enable if you want to easily `manage existing <script>` tags. Check [manage third party scripts](#manage-third-party-scripts)     |
-| `remove_cookie_tables`| boolean  	| false   	| Enable if you want to remove the html cookie tables (but still want to make use of `autoclear_cookies`)                           |
-| `hide_from_bots`      | boolean  	| false   	| Enable if you don't want the plugin to run when a bot/crawler/webdriver is detected       |
-| `gui_options`         | object  	| -   	    | Customization option which allows to choose layout, position	and transition. Check [layout options & customization](#layout-options--customization) |
-| __`onAccept`__      	| function 	| -       	| Method run on: <br>  1. the moment the cookie consent is accepted <br> 2. after each page load (if cookie consent has already been accepted) |
-| __`onChange`__      	| function 	| -       	| Method run `whenever preferences are modified` (and only if cookie consent has already been accepted)                             |
-| __`onFirstAction`__   | function 	| -       	| Method run only `once` when the user makes the initial choice (accept/reject)                                                     |
-| `languages`      	    | object 	| -       	| [Check below](#how-to-configure-languages--cookie-settings) for configuration
+| Option | Type | Default | Description |
+|--------------------- |---------- |--------- |---------------------------------------------------------------------------------------------------------------------------------- |
+| `autorun` | boolean | true | If enabled, show the cookie consent as soon as possible (otherwise you need to manually call the `.show()` method) |
+| `delay` | number | 0 | Number of `milliseconds` before showing the consent-modal |
+| `mode` | string | 'opt-in' |Accepted values: <br> - `opt-in`: scripts will not run unless consent is given (gdpr compliant) <br> - `opt-out`: scripts — that have categories set as `enabled` by default — will run without consent, until an explicit choice is made |
+| `cookie_expiration` | number | 182 | Number of days before the cookie expires (182 days = 6 months) |
+| `cookie_necessary_only_expiration` | number | - | Specify if you want to set a different number of days - before the cookie expires - when the user accepts only the necessary categories |
+| `cookie_path` | string | "/" | Path where the cookie will be set |
+| `cookie_domain` | string | location.hostname | Specify your domain (will be grabbed by default) or a subdomain |
+| `cookie_same_site` | string | "Lax" | SameSite attribute |
+| `use_rfc_cookie` | boolean | false | Enable if you want the value of the cookie to be rfc compliant |
+| `force_consent` | boolean | false | Enable if you want to block page navigation until user action (check [faq](#faq) for a proper implementation) |
+| `revision` | number | 0 | Specify this option to enable revisions. [Check below](#how-to-enablemanage-revisions) for a proper usage |
+| `current_lang` | string | - | Specify one of the languages you have defined (can also be dynamic): `'en'`, `'de'` ... |
+| `auto_language` | string | null | Language auto-detection strategy. Null to disable (default), `"browser"` to get user's browser language or `"document"` to read value from `<html lang="...">` of current page. If language is not defined => use specified `current_lang` |
+| `autoclear_cookies` | boolean | false | Enable if you want to automatically delete cookies when user opts-out of a specific category inside cookie settings |
+| `page_scripts` | boolean | false | Enable if you want to easily `manage existing <script>` tags. Check [manage third party scripts](#manage-third-party-scripts) |
+| `remove_cookie_tables`| boolean | false | Enable if you want to remove the html cookie tables (but still want to make use of `autoclear_cookies`) |
+| `hide_from_bots` | boolean | false | Enable if you don't want the plugin to run when a bot/crawler/webdriver is detected |
+| `gui_options` | object | - | Customization option which allows to choose layout, position and transition. Check [layout options & customization](#layout-options--customization) |
+| **`onAccept`** | function | - | Method run on: <br> 1. the moment the cookie consent is accepted <br> 2. after each page load (if cookie consent has already been accepted) |
+| **`onChange`** | function | - | Method run `whenever preferences are modified` (and only if cookie consent has already been accepted) |
+| **`onFirstAction`** | function | - | Method run only `once` when the user makes the initial choice (accept/reject) |
+| `languages` | object | - | [Check below](#how-to-configure-languages--cookie-settings) for configuration
 
 ## Full example configurations
--   <details><summary>Configuration with gtag.js - Google Analytics</summary>
-    <p>
 
-    1. enable `page_scripts`
-    2. set `type="text/plain"` and `data-cookiecategory="<your-category>"` to each script:
+- <details><summary>Configuration with gtag.js - Google Analytics</summary>
+  <p>
 
-    <br>
+  1. enable `page_scripts`
+  2. set `type="text/plain"` and `data-cookiecategory="<your-category>"` to each script:
 
-    ```html
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script type="text/plain" data-cookiecategory="analytics" async src="https://www.googletagmanager.com/gtag/js?id=GA_MEASUREMENT_ID"></script>
-    <script type="text/plain" data-cookiecategory="analytics">
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){window.dataLayer.push(arguments);}
-        gtag('js', new Date());
+  <br>
 
-        gtag('config', 'GA_MEASUREMENT_ID');
-    </script>
+  ```html
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script
+    type="text/plain"
+    data-cookiecategory="analytics"
+    async
+    src="https://www.googletagmanager.com/gtag/js?id=GA_MEASUREMENT_ID"
+  ></script>
+  <script type="text/plain" data-cookiecategory="analytics">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){window.dataLayer.push(arguments);}
+    gtag('js', new Date());
 
-    <script defer src="<path-to-cookieconsent.js>"></script>
-    <script>
-        window.addEventListener('load', function () {
-            // obtain cookieconsent plugin
-            var cookieconsent = initCookieConsent();
+    gtag('config', 'GA_MEASUREMENT_ID');
+  </script>
 
-            // run plugin with config object
-            cookieconsent.run({
-                autorun: true,
-                current_lang: 'en',
-                autoclear_cookies: true,
-                page_scripts: true,
+  <script defer src="<path-to-cookieconsent.js>"></script>
+  <script>
+    window.addEventListener("load", function () {
+      // obtain cookieconsent plugin
+      var cookieconsent = initCookieConsent();
 
-                onFirstAction: function(user_preferences, cookie){
-                    // callback triggered only once
+      // run plugin with config object
+      cookieconsent.run({
+        autorun: true,
+        current_lang: "en",
+        autoclear_cookies: true,
+        page_scripts: true,
+
+        onFirstAction: function (user_preferences, cookie) {
+          // callback triggered only once
+        },
+
+        onAccept: function (cookie) {
+          // ... cookieconsent accepted
+        },
+
+        onChange: function (cookie, changed_preferences) {
+          // ... cookieconsent preferences were changed
+        },
+
+        languages: {
+          en: {
+            consent_modal: {
+              title: "I use cookies",
+              description:
+                'Hi, this website uses essential cookies to ensure its proper operation and tracking cookies to understand how you interact with it. The latter will be set only upon approval. <a aria-label="Cookie policy" class="cc-link" href="#">Read more</a>',
+              primary_btn: {
+                text: "Accept",
+                role: "accept_all", // 'accept_selected' or 'accept_all'
+              },
+              secondary_btn: {
+                text: "Settings",
+                role: "settings", // 'settings' or 'accept_necessary'
+              },
+            },
+            settings_modal: {
+              title: "Cookie preferences",
+              save_settings_btn: "Save settings",
+              accept_all_btn: "Accept all",
+              reject_all_btn: "Reject all", // optional, [v.2.5.0 +]
+              cookie_table_headers: [
+                { col1: "Name" },
+                { col2: "Domain" },
+                { col3: "Expiration" },
+                { col4: "Description" },
+                { col5: "Type" },
+              ],
+              blocks: [
+                {
+                  title: "Cookie usage",
+                  description:
+                    "I use cookies to ensure the basic functionalities of the website and to enhance your online experience. You can choose for each category to opt-in/out whenever you want.",
                 },
-
-                onAccept: function (cookie) {
-                    // ... cookieconsent accepted
+                {
+                  title: "Strictly necessary cookies",
+                  description:
+                    "These cookies are essential for the proper functioning of my website. Without these cookies, the website would not work properly.",
+                  toggle: {
+                    value: "necessary",
+                    enabled: true,
+                    readonly: true,
+                  },
                 },
-
-                onChange: function (cookie, changed_preferences) {
-                    // ... cookieconsent preferences were changed
+                {
+                  title: "Analytics cookies",
+                  description:
+                    "These cookies collect information about how you use the website, which pages you visited and which links you clicked on. All of the data is anonymized and cannot be used to identify you.",
+                  toggle: {
+                    value: "analytics",
+                    enabled: false,
+                    readonly: false,
+                  },
+                  cookie_table: [
+                    {
+                      col1: "^_ga",
+                      col2: "google.com",
+                      col3: "2 years",
+                      col4: "description ...",
+                      col5: "Permanent cookie",
+                      is_regex: true,
+                    },
+                    {
+                      col1: "_gid",
+                      col2: "google.com",
+                      col3: "1 day",
+                      col4: "description ...",
+                      col5: "Permanent cookie",
+                    },
+                  ],
                 },
+                {
+                  title: "More information",
+                  description:
+                    'For any queries in relation to my policy on cookies and your choices, please <a class="cc-link" href="#yourwebsite">contact me</a>.',
+                },
+              ],
+            },
+          },
+        },
+      });
+    });
+  </script>
+  ```
 
-                languages: {
-                    en: {
-                        consent_modal: {
-                            title: 'I use cookies',
-                            description: 'Hi, this website uses essential cookies to ensure its proper operation and tracking cookies to understand how you interact with it. The latter will be set only upon approval. <a aria-label="Cookie policy" class="cc-link" href="#">Read more</a>',
-                            primary_btn: {
-                                text: 'Accept',
-                                role: 'accept_all'              // 'accept_selected' or 'accept_all'
-                            },
-                            secondary_btn: {
-                                text: 'Settings',
-                                role: 'settings'                // 'settings' or 'accept_necessary'
-                            }
-                        },
-                        settings_modal: {
-                            title: 'Cookie preferences',
-                            save_settings_btn: 'Save settings',
-                            accept_all_btn: 'Accept all',
-                            reject_all_btn: 'Reject all',       // optional, [v.2.5.0 +]
-                            cookie_table_headers: [
-                                {col1: 'Name'},
-                                {col2: 'Domain'},
-                                {col3: 'Expiration'},
-                                {col4: 'Description'},
-                                {col5: 'Type'}
-                            ],
-                            blocks: [
-                                {
-                                    title: 'Cookie usage',
-                                    description: 'I use cookies to ensure the basic functionalities of the website and to enhance your online experience. You can choose for each category to opt-in/out whenever you want.'
-                                }, {
-                                    title: 'Strictly necessary cookies',
-                                    description: 'These cookies are essential for the proper functioning of my website. Without these cookies, the website would not work properly.',
-                                    toggle: {
-                                        value: 'necessary',
-                                        enabled: true,
-                                        readonly: true
-                                    }
-                                }, {
-                                    title: 'Analytics cookies',
-                                    description: 'These cookies collect information about how you use the website, which pages you visited and which links you clicked on. All of the data is anonymized and cannot be used to identify you.',
-                                    toggle: {
-                                        value: 'analytics',
-                                        enabled: false,
-                                        readonly: false
-                                    },
-                                    cookie_table: [
-                                        {
-                                            col1: '^_ga',
-                                            col2: 'google.com',
-                                            col3: '2 years',
-                                            col4: 'description ...',
-                                            col5: 'Permanent cookie',
-                                            is_regex: true
-                                        },
-                                        {
-                                            col1: '_gid',
-                                            col2: 'google.com',
-                                            col3: '1 day',
-                                            col4: 'description ...',
-                                            col5: 'Permanent cookie'
-                                        }
-                                    ]
-                                }, {
-                                    title: 'More information',
-                                    description: 'For any queries in relation to my policy on cookies and your choices, please <a class="cc-link" href="#yourwebsite">contact me</a>.',
-                                }
-                            ]
-                        }
-                    }
-                }
-            });
-        });
-    </script>
-    ```
+  </p>
+  </details>
 
-    </p>
-    </details>
 - More to be added ...
 
 ### How to configure languages & cookie settings
+
 Languages is an object which basically holds all of the text/html of your cookie modals in different languages. In here you can define `cookie categories`, `cookie tables`, `opt-in/out toggle` for each category and more. For each language, a `consent_modal` object and a `settings_modal` object must be configured.
 
 <details><summary>Example with <b>multiple languages</b> ('en' and 'it')</summary>
@@ -881,91 +1003,95 @@ Languages is an object which basically holds all of the text/html of your cookie
 
 ```javascript
 cookieconsent.run({
-    // ...,
-    languages: {
-        'en': {
-            consent_modal: {
-                title: 'Title here ...',
-                description: 'Description here ...',
-                primary_btn: {
-                    text: 'Accept',
-                    role: 'accept_all'      // 'accept_selected' or 'accept_all'
-                },
-                secondary_btn: {
-                    text: 'Settings',
-                    role: 'settings'        // 'settings' or 'accept_necessary'
-                }
-            },
-            settings_modal: {
-                title: 'Cookie preferences ...',
-                save_settings_btn: 'Save settings',
-                accept_all_btn: 'Accept all',
-                blocks: [
-                    {
-                        title: 'First block title ...',
-                        description: 'First block description ...'
-                    }, {
-                        title: 'Second block title ...',
-                        description: 'Second block description ...',
-                        toggle: {
-                            value: 'my_category1',
-                            enabled: true,
-                            readonly: true
-                        }
-                    }, {
-                        title: 'Third block title ...',
-                        description: 'Third block description ...',
-                        toggle: {
-                            value: 'my_category2',
-                            enabled: false,
-                            readonly: false
-                        }
-                    }
-                ]
-            }
+  // ...,
+  languages: {
+    en: {
+      consent_modal: {
+        title: "Title here ...",
+        description: "Description here ...",
+        primary_btn: {
+          text: "Accept",
+          role: "accept_all", // 'accept_selected' or 'accept_all'
         },
-        'it': {
-            consent_modal: {
-                title: 'Title in italian here ...',
-                description: 'Description in italian here ...',
-                primary_btn: {
-                    text: 'Accept in italian',
-                    role: 'accept_all'      //'accept_selected' or 'accept_all'
-                },
-                secondary_btn: {
-                    text: 'Settings',
-                    role: 'settings'        //'settings' or 'accept_necessary'
-                }
+        secondary_btn: {
+          text: "Settings",
+          role: "settings", // 'settings' or 'accept_necessary'
+        },
+      },
+      settings_modal: {
+        title: "Cookie preferences ...",
+        save_settings_btn: "Save settings",
+        accept_all_btn: "Accept all",
+        blocks: [
+          {
+            title: "First block title ...",
+            description: "First block description ...",
+          },
+          {
+            title: "Second block title ...",
+            description: "Second block description ...",
+            toggle: {
+              value: "my_category1",
+              enabled: true,
+              readonly: true,
             },
-            settings_modal: {
-                title: 'Cookie preferences ...',
-                save_settings_btn: 'Save settings in italian',
-                accept_all_btn: "Accept all",
-                blocks: [
-                    {
-                        title: 'First block title in italian ...',
-                        description: 'First block description in italian ...'
-                    }, {
-                        title: 'Second block title in italian ...',
-                        description: 'Second block description in italian...',
-                        toggle: {
-                            value: 'my_category1',
-                            enabled: true,
-                            readonly: true
-                        }
-                    }, {
-                        title: 'Third block title in italian ...',
-                        description: 'Third block description in italian...',
-                        toggle: {
-                            value: 'my_category2',
-                            enabled: false,
-                            readonly: false
-                        }
-                    }
-                ]
-            }
-        }
-    }
+          },
+          {
+            title: "Third block title ...",
+            description: "Third block description ...",
+            toggle: {
+              value: "my_category2",
+              enabled: false,
+              readonly: false,
+            },
+          },
+        ],
+      },
+    },
+    it: {
+      consent_modal: {
+        title: "Title in italian here ...",
+        description: "Description in italian here ...",
+        primary_btn: {
+          text: "Accept in italian",
+          role: "accept_all", //'accept_selected' or 'accept_all'
+        },
+        secondary_btn: {
+          text: "Settings",
+          role: "settings", //'settings' or 'accept_necessary'
+        },
+      },
+      settings_modal: {
+        title: "Cookie preferences ...",
+        save_settings_btn: "Save settings in italian",
+        accept_all_btn: "Accept all",
+        blocks: [
+          {
+            title: "First block title in italian ...",
+            description: "First block description in italian ...",
+          },
+          {
+            title: "Second block title in italian ...",
+            description: "Second block description in italian...",
+            toggle: {
+              value: "my_category1",
+              enabled: true,
+              readonly: true,
+            },
+          },
+          {
+            title: "Third block title in italian ...",
+            description: "Third block description in italian...",
+            toggle: {
+              value: "my_category2",
+              enabled: false,
+              readonly: false,
+            },
+          },
+        ],
+      },
+    },
+  },
 });
 ```
 
@@ -985,245 +1111,258 @@ You can create tables with a custom number of columns to explain what each cooki
 </details>
 
 ## How to enable/manage revisions
+
 Note:
+
 - default revision number is 0
 - if existing revision number is different from the one you just specified => show consent modal
 
 1. Enable revisions by specifying a valid `revision` parameter:
 
-    ```javascript
-    cookieconsent.run({
-        // ...,
-        revision: 1,
-        // ...
-    })
-    ```
+   ```javascript
+   cookieconsent.run({
+     // ...,
+     revision: 1,
+     // ...
+   });
+   ```
 
 2. Set a valid `revision_message` parameter (optional) inside `consent_modal`, and add the following placeholder `{{revision_message}}` inside `description`:
 
-    ```javascript
-    cookieconsent.run({
-        // ...,
-        revision: 1,
-        // ...,
-        languages: {
-            en: {
-                consent_modal: {
-                    // ...,
-                    description: 'Usual description ... {{revision_message}}',
-                    revision_message: '<br> Dude, my terms have changed. Sorry for bothering you again!',
-                    // ...
-                },
-                // ...
-            }
-        }
-        // ...
-    })
-    ```
+   ```javascript
+   cookieconsent.run({
+     // ...,
+     revision: 1,
+     // ...,
+     languages: {
+       en: {
+         consent_modal: {
+           // ...,
+           description: "Usual description ... {{revision_message}}",
+           revision_message:
+             "<br> Dude, my terms have changed. Sorry for bothering you again!",
+           // ...
+         },
+         // ...
+       },
+     },
+     // ...
+   });
+   ```
 
 ## FAQ
--   <details><summary>How to enable dark-mode</summary>
-    <p>
 
-    Either manually add the following class `c_darkmode` to the body/html tag, or toggle it via javascript:
-    ```javascript
-    document.body.classList.toggle('c_darkmode');
-    ```
+- <details><summary>How to enable dark-mode</summary>
+  <p>
 
-    </p>
-    </details>
--   <details><summary>How to add link/button to open cookie settings</summary>
-    <p>
+  Either manually add the following class `c_darkmode` to the body/html tag, or toggle it via javascript:
 
-    Create a button (or link) with `data-cc="c-settings"` attribute:
-    ```javascript
-    <button type="button" aria-label="View cookie settings" data-cc="c-settings">Cookie Settings</button>
-    ```
+  ```javascript
+  document.body.classList.toggle("c_darkmode");
+  ```
 
-    </p>
-    </details>
--   <details><summary>How to integrate with my multi-language website</summary>
-    <p>
+  </p>
+  </details>
 
-    If you have multiple versions of your html page, each with a different &lt;html <b>lang="..."</b> &gt; attribute, you can grab this value using:
+- <details><summary>How to add link/button to open cookie settings</summary>
+  <p>
 
-    ```javascript
-    document.documentElement.getAttribute('lang');
-    ```
+  Create a button (or link) with `data-cc="c-settings"` attribute:
 
-    and then set it as `current_lang` value like this:
+  ```javascript
+  <button type="button" aria-label="View cookie settings" data-cc="c-settings">
+    Cookie Settings
+  </button>
+  ```
+
+  </p>
+  </details>
+
+- <details><summary>How to integrate with my multi-language website</summary>
+  <p>
+
+  If you have multiple versions of your html page, each with a different &lt;html <b>lang="..."</b> &gt; attribute, you can grab this value using:
+
+  ```javascript
+  document.documentElement.getAttribute("lang");
+  ```
+
+  and then set it as `current_lang` value like this:
+
+  ```javascript
+  cookieconsent.run({
+    // ...
+    current_lang: document.documentElement.getAttribute("lang"),
+    // ...
+  });
+  ```
+
+  **Note**: make sure that the lang attribute's value format (example: 'en' => 2 characters) is identical to the ones you defined. If you have 'en-US' as lang attribute, make sure to also specify 'en-US' (and not just 'en') in the config. parameters.
+
+  </p>
+  </details>
+
+- <details><summary>How to load scripts after a specific cookie category has been accepted</summary>
+  <p>
+
+  Suppose you have a `analytics.js` file you want to load after the `analytics` category has been accepted:
+
+  - <details><summary>Method 1 (recommended)</summary>
+      <p>
+
+    1. enable `page_scripts`:
+
+       ```javascript
+       cookieconsent.run({
+         // ...
+         page_scripts: true,
+         // ...
+       });
+       ```
+
+    2. add a `<script>` tag with the following attributes: `type="text/plain"` and `data-cookiecategory="<category>"`
+
+       ```html
+       <script
+         type="text/plain"
+         data-cookiecategory="analytics"
+         src="<path-to-analytics.js>"
+       ></script>
+       ```
+
+      </p>
+      </details>
+
+  - <details><summary>Method 2</summary>
+      <p>
+
+    Load script using the `.loadScript()` method inside the `onAccept` method:
 
     ```javascript
     cookieconsent.run({
-        // ...
-        current_lang: document.documentElement.getAttribute('lang'),
-        // ...
+      // ...
+      onAccept: function () {
+        if (cookieconsent.allowedCategory("analytics")) {
+          cookieconsent.loadScript("<path-to-analytics.js", function () {
+            // script loaded ...
+          });
+        }
+      },
     });
     ```
 
-    **Note**: make sure that the lang attribute's value format (example: 'en' => 2 characters) is identical to the ones you defined. If you have 'en-US' as lang attribute, make sure to also specify 'en-US' (and not just 'en') in the config. parameters.
+      </p>
+      </details>
 
-    </p>
-    </details>
+  </p>
+  </details>
 
--   <details><summary>How to load scripts after a specific cookie category has been accepted</summary>
-    <p>
+- <details><summary>Make consent required (block page navigation until action)</summary>
+  <p>
 
-    Suppose you have a `analytics.js` file you want to load after the `analytics` category has been accepted:
-    - <details><summary>Method 1 (recommended)</summary>
-        <p>
+  This is a css only solution:
 
-        1. enable `page_scripts`:
+  1. enable `force_consent` option:
+     ```javascript
+     cookieconsent.run({
+       // ...
+       force_consent: true,
+       // ...
+     });
+     ```
+  2. That should do it. If you want to remove the weird horizontal jump (due to the scrollbar disappearing) you can add the following style **inside the head tag** of your page:
+  `html <style> html, body { height: auto!important; width: 100vw!important; overflow-x: hidden!important; } </style> `
+  For a full example check the <a href="demo/index2.html">second demo</a>.
+  </p>
+  </details>
 
-            ```javascript
-            cookieconsent.run({
-                // ...
-                page_scripts: true,
-                // ...
-            });
-            ```
-        2. add a `<script>` tag with the following attributes: `type="text/plain"` and `data-cookiecategory="<category>"`
+- <details><summary>How to create custom cookie tables</summary>
+  <p>
 
-            ```html
-            <script type="text/plain" data-cookiecategory="analytics" src="<path-to-analytics.js>"></script>
-            ```
-
-        </p>
-        </details>
-    - <details><summary>Method 2</summary>
-        <p>
-
-        Load script using the `.loadScript()` method inside the `onAccept` method:
-
-        ```javascript
-        cookieconsent.run({
-            // ...
-            onAccept: function () {
-                if (cookieconsent.allowedCategory('analytics')) {
-                    cookieconsent.loadScript('<path-to-analytics.js', function () {
-                        // script loaded ...
-                    });
-                }
-            }
-        })
-        ```
-        </p>
-        </details>
-
-    </p>
-    </details>
--   <details><summary>Make consent required (block page navigation until action)</summary>
-    <p>
-
-    This is a css only solution:
-
-    1. enable `force_consent` option:
-        ```javascript
-        cookieconsent.run({
-            // ...
-            force_consent: true,
-            // ...
-        });
-        ```
-    2. That should do it. If you want to remove the weird horizontal jump (due to the scrollbar disappearing) you can add the following style **inside the head tag** of your page:
-        ```html
-        <style>
-            html,
-            body {
-                height: auto!important;
-                width: 100vw!important;
-                overflow-x: hidden!important;
-            }
-        </style>
-        ```
-    For a full example check the <a href="demo/index2.html">second demo</a>.
-    </p>
-    </details>
--   <details><summary>How to create custom cookie tables</summary>
-    <p>
-
-    - **Cookie tables are defined by you, that is you choose how many columns and what their naming will be**
-    - **Make sure that the first column of the table contains the name of the cookie for <code>autoclear_cookie</code> to work properly**
+  - **Cookie tables are defined by you, that is you choose how many columns and what their naming will be**
+  - **Make sure that the first column of the table contains the name of the cookie for <code>autoclear_cookie</code> to work properly**
     <br>
 
-    1. Specify the table structure via the `cookie_table_headers` property inside `settings_modal` object:
+  1. Specify the table structure via the `cookie_table_headers` property inside `settings_modal` object:
 
-        Example with 3 columns:
+     Example with 3 columns:
 
-        ```javascript
-        // ...
-        cookie_table_headers: [
-            {col1: "Name"},
-            {col2: "Source"},
-            {col3: "Description"},
-        ]
-        // ...
-        ```
+     ```javascript
+     // ...
+     cookie_table_headers: [
+       { col1: "Name" },
+       { col2: "Source" },
+       { col3: "Description" },
+     ];
+     // ...
+     ```
 
-    2. Now you can create a `cookie_table` array of objects:
+  2. Now you can create a `cookie_table` array of objects:
 
-        ```javascript
-        // ...
-        cookie_table: [
-            {
-                col1: '_ga',
-                col2: 'google.com',
-                col3: 'description ..',
-            },
-            {
-                col1: '_gid',
-                col2: 'google.com',
-                col3: 'description ..',
-            }
-        ]
-        // ...
-        ```
+     ```javascript
+     // ...
+     cookie_table: [
+       {
+         col1: "_ga",
+         col2: "google.com",
+         col3: "description ..",
+       },
+       {
+         col1: "_gid",
+         col2: "google.com",
+         col3: "description ..",
+       },
+     ];
+     // ...
+     ```
 
-    **Check the examples above for a valid implementation.**
-    </p>
-    </details>
--   <details><summary>How to use in React</summary>
-    <p>
+  **Check the examples above for a valid implementation.**
+  </p>
+  </details>
 
-    1. Create a new component: `CookieConsent.js`
+- <details><summary>How to use in React</summary>
+  <p>
 
-        ```javascript
-        import { useEffect } from "react";
+  1.  Create a new component: `CookieConsent.js`
 
-        import "./<path-to-cookieconsent.css>";
-        import "./<path-to-cookieconsent.js>";
+      ```javascript
+      import { useEffect } from "react";
 
-        export default function CookieConsent() {
-            useEffect(() => {
-                const cc = window.initCookieConsent();
+      import "./<path-to-cookieconsent.css>";
+      import "./<path-to-cookieconsent.js>";
 
-                cc.run({
-                    // your config
-                });
+      export default function CookieConsent() {
+        useEffect(() => {
+          const cc = window.initCookieConsent();
 
-            }, []);
+          cc.run({
+            // your config
+          });
+        }, []);
 
-            return null;
-        }
-        ```
+        return null;
+      }
+      ```
 
-    2. Import the component only once (generally in your main/root component like `App.js` or `index.js`)
+  2.  Import the component only once (generally in your main/root component like `App.js` or `index.js`)
 
-        ```javascript
-        import CookieConsent from "./<path-to-CookieConsent.js-component>";
+          ```javascript
+          import CookieConsent from "./<path-to-CookieConsent.js-component>";
 
-        export default function App() {
-            return (
-                <div className="App">
-                    <h1>Hello World</h1>
+          export default function App() {
+              return (
+                  <div className="App">
+                      <h1>Hello World</h1>
 
-                    <CookieConsent/>
-                </div>
-            );
-        }
-        ```
-    </p>
-    </details>
+                      <CookieConsent/>
+                  </div>
+              );
+          }
+          ```
+
+      </p>
+      </details>
 
 ## License
+
 Distributed under the MIT License. See [LICENSE](https://github.com/orestbida/cookieconsent/blob/master/LICENSE) for more information.

--- a/demo/demo_basic/cookieconsent-init.js
+++ b/demo/demo_basic/cookieconsent-init.js
@@ -3,149 +3,149 @@ var cc = initCookieConsent();
 
 // microsoft logo
 var logo =
-  '<svg style="width: 110px; height: 30px; display: block;" xmlns="http://www.w3.org/2000/svg" xml:space="preserve" viewBox="0 0 337.6 72"><path fill="#737373" d="M140.4 14.4v43.2h-7.5V23.7h-.1l-13.4 33.9h-5l-13.7-33.9h-.1v33.9h-6.9V14.4h10.8l12.4 32h.2l13.1-32h10.2zm6.2 3.3c0-1.2.4-2.2 1.3-3 .9-.8 1.9-1.2 3.1-1.2 1.3 0 2.4.4 3.2 1.2s1.3 1.8 1.3 3-.4 2.2-1.3 3c-.9.8-1.9 1.2-3.2 1.2s-2.3-.4-3.1-1.2c-.8-.9-1.3-1.9-1.3-3zm8.1 8.9v31h-7.3v-31h7.3zm22.1 25.7c1.1 0 2.3-.2 3.6-.8 1.3-.5 2.5-1.2 3.6-2v6.8c-1.2.7-2.5 1.2-4 1.5-1.5.3-3.1.5-4.9.5-4.6 0-8.3-1.4-11.1-4.3-2.9-2.9-4.3-6.6-4.3-11 0-5 1.5-9.1 4.4-12.3 2.9-3.2 7-4.8 12.4-4.8 1.4 0 2.8.2 4.1.5 1.4.3 2.5.8 3.3 1.2v7c-1.1-.8-2.3-1.5-3.4-1.9-1.2-.4-2.4-.7-3.6-.7-2.9 0-5.2.9-7 2.8s-2.6 4.4-2.6 7.6c0 3.1.9 5.6 2.6 7.3 1.7 1.7 4 2.6 6.9 2.6zm27.9-26.2a8.08 8.08 0 0 1 2.8.4v7.4c-.4-.3-.9-.6-1.7-.8s-1.6-.4-2.7-.4c-1.8 0-3.3.8-4.5 2.3s-1.9 3.8-1.9 7v15.6h-7.3v-31h7.3v4.9h.1c.7-1.7 1.7-3 3-4 1.4-.9 3-1.4 4.9-1.4zm3.2 16.5c0-5.1 1.5-9.2 4.3-12.2 2.9-3 6.9-4.5 12-4.5 4.8 0 8.6 1.4 11.3 4.3s4.1 6.8 4.1 11.7c0 5-1.5 9-4.3 12-2.9 3-6.8 4.5-11.8 4.5-4.8 0-8.6-1.4-11.4-4.2-2.8-2.9-4.2-6.8-4.2-11.6zm7.6-.3c0 3.2.7 5.7 2.2 7.4s3.6 2.6 6.3 2.6c2.6 0 4.7-.8 6.1-2.6 1.4-1.7 2.1-4.2 2.1-7.6 0-3.3-.7-5.8-2.1-7.6-1.4-1.7-3.5-2.6-6-2.6-2.7 0-4.7.9-6.2 2.7-1.7 1.9-2.4 4.4-2.4 7.7zm35-7.5c0 1 .3 1.9 1 2.5.7.6 2.1 1.3 4.4 2.2 2.9 1.2 5 2.5 6.1 3.9a8.1 8.1 0 0 1 1.8 5.3c0 2.9-1.1 5.2-3.4 7-2.2 1.8-5.3 2.6-9.1 2.6-1.3 0-2.7-.2-4.3-.5-1.6-.3-2.9-.7-4-1.2v-7.2c1.3.9 2.8 1.7 4.3 2.2 1.5.5 2.9.8 4.2.8 1.6 0 2.9-.2 3.6-.7.8-.5 1.2-1.2 1.2-2.3 0-1-.4-1.8-1.2-2.6-.8-.7-2.4-1.5-4.6-2.4-2.7-1.1-4.6-2.4-5.7-3.8s-1.7-3.2-1.7-5.4c0-2.8 1.1-5.1 3.3-6.9 2.2-1.8 5.1-2.7 8.6-2.7 1.1 0 2.3.1 3.6.4s2.5.6 3.4.9V34c-1-.6-2.1-1.2-3.4-1.7-1.3-.5-2.6-.7-3.8-.7-1.4 0-2.5.3-3.2.8-.7.7-1.1 1.4-1.1 2.4zm16.4 7.8c0-5.1 1.5-9.2 4.3-12.2 2.9-3 6.9-4.5 12-4.5 4.8 0 8.6 1.4 11.3 4.3s4.1 6.8 4.1 11.7c0 5-1.5 9-4.3 12-2.9 3-6.8 4.5-11.8 4.5-4.8 0-8.6-1.4-11.4-4.2-2.7-2.9-4.2-6.8-4.2-11.6zm7.6-.3c0 3.2.7 5.7 2.2 7.4s3.6 2.6 6.3 2.6c2.6 0 4.7-.8 6.1-2.6 1.4-1.7 2.1-4.2 2.1-7.6 0-3.3-.7-5.8-2.1-7.6-1.4-1.7-3.5-2.6-6-2.6-2.7 0-4.7.9-6.2 2.7-1.6 1.9-2.4 4.4-2.4 7.7zm48.4-9.7H312v25h-7.4v-25h-5.2v-6h5.2v-4.3c0-3.2 1.1-5.9 3.2-8s4.8-3.1 8.1-3.1c.9 0 1.7.1 2.4.1s1.3.2 1.8.4V18c-.2-.1-.7-.3-1.3-.5-.6-.2-1.3-.3-2.1-.3-1.5 0-2.7.5-3.5 1.4-.8.9-1.2 2.4-1.2 4.2v3.7h10.9v-7l7.3-2.2v9.2h7.4v6h-7.4V47c0 1.9.4 3.2 1 4 .7.8 1.8 1.2 3.3 1.2.4 0 .9-.1 1.5-.3.6-.2 1.1-.4 1.5-.7v6c-.5.3-1.2.5-2.3.7-1.1.2-2.1.3-3.2.3-3.1 0-5.4-.8-6.9-2.4-1.5-1.6-2.3-4.1-2.3-7.4l.1-15.8z"/><path fill="#f25022" d="M0 0h34.2v34.2H0z"/><path fill="#7fba00" d="M37.8 0H72v34.2H37.8z"/><path fill="#00a4ef" d="M0 37.8h34.2V72H0z"/><path fill="#ffb900" d="M37.8 37.8H72V72H37.8z"/></svg>';
+    '<svg style="width: 110px; height: 30px; display: block;" xmlns="http://www.w3.org/2000/svg" xml:space="preserve" viewBox="0 0 337.6 72"><path fill="#737373" d="M140.4 14.4v43.2h-7.5V23.7h-.1l-13.4 33.9h-5l-13.7-33.9h-.1v33.9h-6.9V14.4h10.8l12.4 32h.2l13.1-32h10.2zm6.2 3.3c0-1.2.4-2.2 1.3-3 .9-.8 1.9-1.2 3.1-1.2 1.3 0 2.4.4 3.2 1.2s1.3 1.8 1.3 3-.4 2.2-1.3 3c-.9.8-1.9 1.2-3.2 1.2s-2.3-.4-3.1-1.2c-.8-.9-1.3-1.9-1.3-3zm8.1 8.9v31h-7.3v-31h7.3zm22.1 25.7c1.1 0 2.3-.2 3.6-.8 1.3-.5 2.5-1.2 3.6-2v6.8c-1.2.7-2.5 1.2-4 1.5-1.5.3-3.1.5-4.9.5-4.6 0-8.3-1.4-11.1-4.3-2.9-2.9-4.3-6.6-4.3-11 0-5 1.5-9.1 4.4-12.3 2.9-3.2 7-4.8 12.4-4.8 1.4 0 2.8.2 4.1.5 1.4.3 2.5.8 3.3 1.2v7c-1.1-.8-2.3-1.5-3.4-1.9-1.2-.4-2.4-.7-3.6-.7-2.9 0-5.2.9-7 2.8s-2.6 4.4-2.6 7.6c0 3.1.9 5.6 2.6 7.3 1.7 1.7 4 2.6 6.9 2.6zm27.9-26.2a8.08 8.08 0 0 1 2.8.4v7.4c-.4-.3-.9-.6-1.7-.8s-1.6-.4-2.7-.4c-1.8 0-3.3.8-4.5 2.3s-1.9 3.8-1.9 7v15.6h-7.3v-31h7.3v4.9h.1c.7-1.7 1.7-3 3-4 1.4-.9 3-1.4 4.9-1.4zm3.2 16.5c0-5.1 1.5-9.2 4.3-12.2 2.9-3 6.9-4.5 12-4.5 4.8 0 8.6 1.4 11.3 4.3s4.1 6.8 4.1 11.7c0 5-1.5 9-4.3 12-2.9 3-6.8 4.5-11.8 4.5-4.8 0-8.6-1.4-11.4-4.2-2.8-2.9-4.2-6.8-4.2-11.6zm7.6-.3c0 3.2.7 5.7 2.2 7.4s3.6 2.6 6.3 2.6c2.6 0 4.7-.8 6.1-2.6 1.4-1.7 2.1-4.2 2.1-7.6 0-3.3-.7-5.8-2.1-7.6-1.4-1.7-3.5-2.6-6-2.6-2.7 0-4.7.9-6.2 2.7-1.7 1.9-2.4 4.4-2.4 7.7zm35-7.5c0 1 .3 1.9 1 2.5.7.6 2.1 1.3 4.4 2.2 2.9 1.2 5 2.5 6.1 3.9a8.1 8.1 0 0 1 1.8 5.3c0 2.9-1.1 5.2-3.4 7-2.2 1.8-5.3 2.6-9.1 2.6-1.3 0-2.7-.2-4.3-.5-1.6-.3-2.9-.7-4-1.2v-7.2c1.3.9 2.8 1.7 4.3 2.2 1.5.5 2.9.8 4.2.8 1.6 0 2.9-.2 3.6-.7.8-.5 1.2-1.2 1.2-2.3 0-1-.4-1.8-1.2-2.6-.8-.7-2.4-1.5-4.6-2.4-2.7-1.1-4.6-2.4-5.7-3.8s-1.7-3.2-1.7-5.4c0-2.8 1.1-5.1 3.3-6.9 2.2-1.8 5.1-2.7 8.6-2.7 1.1 0 2.3.1 3.6.4s2.5.6 3.4.9V34c-1-.6-2.1-1.2-3.4-1.7-1.3-.5-2.6-.7-3.8-.7-1.4 0-2.5.3-3.2.8-.7.7-1.1 1.4-1.1 2.4zm16.4 7.8c0-5.1 1.5-9.2 4.3-12.2 2.9-3 6.9-4.5 12-4.5 4.8 0 8.6 1.4 11.3 4.3s4.1 6.8 4.1 11.7c0 5-1.5 9-4.3 12-2.9 3-6.8 4.5-11.8 4.5-4.8 0-8.6-1.4-11.4-4.2-2.7-2.9-4.2-6.8-4.2-11.6zm7.6-.3c0 3.2.7 5.7 2.2 7.4s3.6 2.6 6.3 2.6c2.6 0 4.7-.8 6.1-2.6 1.4-1.7 2.1-4.2 2.1-7.6 0-3.3-.7-5.8-2.1-7.6-1.4-1.7-3.5-2.6-6-2.6-2.7 0-4.7.9-6.2 2.7-1.6 1.9-2.4 4.4-2.4 7.7zm48.4-9.7H312v25h-7.4v-25h-5.2v-6h5.2v-4.3c0-3.2 1.1-5.9 3.2-8s4.8-3.1 8.1-3.1c.9 0 1.7.1 2.4.1s1.3.2 1.8.4V18c-.2-.1-.7-.3-1.3-.5-.6-.2-1.3-.3-2.1-.3-1.5 0-2.7.5-3.5 1.4-.8.9-1.2 2.4-1.2 4.2v3.7h10.9v-7l7.3-2.2v9.2h7.4v6h-7.4V47c0 1.9.4 3.2 1 4 .7.8 1.8 1.2 3.3 1.2.4 0 .9-.1 1.5-.3.6-.2 1.1-.4 1.5-.7v6c-.5.3-1.2.5-2.3.7-1.1.2-2.1.3-3.2.3-3.1 0-5.4-.8-6.9-2.4-1.5-1.6-2.3-4.1-2.3-7.4l.1-15.8z"/><path fill="#f25022" d="M0 0h34.2v34.2H0z"/><path fill="#7fba00" d="M37.8 0H72v34.2H37.8z"/><path fill="#00a4ef" d="M0 37.8h34.2V72H0z"/><path fill="#ffb900" d="M37.8 37.8H72V72H37.8z"/></svg>';
 var cookie = "🍪";
 
 // run plugin with config object
 cc.run({
-  current_lang: "en",
-  autoclear_cookies: true, // default: false
-  cookie_name: "cc_cookie_demo1", // default: 'cc_cookie'
-  cookie_expiration: 365, // default: 182
-  page_scripts: true, // default: false
+    current_lang: "en",
+    autoclear_cookies: true, // default: false
+    cookie_name: "cc_cookie_demo1", // default: 'cc_cookie'
+    cookie_expiration: 365, // default: 182
+    page_scripts: true, // default: false
 
-  // auto_language: null,                     // default: null; could also be 'browser' or 'document'
-  // autorun: true,                           // default: true
-  // delay: 0,                                // default: 0
-  // force_consent: false,
-  // hide_from_bots: false,                   // default: false
-  // remove_cookie_tables: false              // default: false
-  // cookie_domain: location.hostname,        // default: current domain
-  // cookie_path: "/",                        // default: root
-  // cookie_same_site: "Lax",
-  // use_rfc_cookie: false,                   // default: false
-  // revision: 0,                             // default: 0
+    // auto_language: null,                     // default: null; could also be 'browser' or 'document'
+    // autorun: true,                           // default: true
+    // delay: 0,                                // default: 0
+    // force_consent: false,
+    // hide_from_bots: false,                   // default: false
+    // remove_cookie_tables: false              // default: false
+    // cookie_domain: location.hostname,        // default: current domain
+    // cookie_path: "/",                        // default: root
+    // cookie_same_site: "Lax",
+    // use_rfc_cookie: false,                   // default: false
+    // revision: 0,                             // default: 0
 
-  gui_options: {
-    consent_modal: {
-      layout: "bar", // box,cloud,bar
-      position: "bottom right", // bottom,middle,top + left,right,center
-      transition: "slide", // zoom,slide
+    gui_options: {
+        consent_modal: {
+            layout: "bar", // box,cloud,bar
+            position: "bottom right", // bottom,middle,top + left,right,center
+            transition: "slide", // zoom,slide
+        },
+        settings_modal: {
+            layout: "box", // box,bar
+            // position: 'left',                // right,left (available only if bar layout selected)
+            transition: "slide", // zoom,slide
+        },
     },
-    settings_modal: {
-      layout: "box", // box,bar
-      // position: 'left',                // right,left (available only if bar layout selected)
-      transition: "slide", // zoom,slide
+
+    onFirstAction: function () {
+        console.log("onFirstAction fired");
     },
-  },
 
-  onFirstAction: function () {
-    console.log("onFirstAction fired");
-  },
-
-  onAccept: function (cookie) {
-    console.log("onAccept fired ...");
-  },
-
-  onChange: function (cookie, changed_preferences) {
-    console.log("onChange fired ...");
-  },
-
-  languages: {
-    en: {
-      consent_modal: {
-        title: cookie + " We use cookies! ",
-        description:
-          'Hi, this website uses essential cookies to ensure its proper operation and tracking cookies to understand how you interact with it. The latter will be set only after consent. <button type="button" data-cc="c-settings" class="cc-link">Let me choose</button>',
-        primary_btn: {
-          text: "Accept all",
-          role: "accept_all", // 'accept_selected' or 'accept_all'
-        },
-        secondary_btn: {
-          text: "Reject all",
-          role: "accept_necessary", // 'settings' or 'accept_necessary'
-        },
-        imprint_link: {
-          // 'optional to display imprint link on the modal or remove it'
-          text: "imprint",
-          url: "/imprint.html",
-        },
-        privacy_policy_link: {
-          // 'optional to display privacy policy link on the modal or remove it'
-          text: "privacy policy",
-          url: "/privacy.html",
-        },
-      },
-      settings_modal: {
-        title: logo,
-        save_settings_btn: "Save settings",
-        accept_all_btn: "Accept all",
-        reject_all_btn: "Reject all",
-        close_btn_label: "Close",
-        cookie_table_headers: [
-          { col1: "Name" },
-          { col2: "Domain" },
-          { col3: "Expiration" },
-          { col4: "Description" },
-        ],
-        blocks: [
-          {
-            title: "Cookie usage 📢",
-            description:
-              'I use cookies to ensure the basic functionalities of the website and to enhance your online experience. You can choose for each category to opt-in/out whenever you want. For more details relative to cookies and other sensitive data, please read the full <a href="#" class="cc-link">privacy policy</a>.',
-          },
-          {
-            title: "Strictly necessary cookies",
-            description:
-              "These cookies are essential for the proper functioning of my website. Without these cookies, the website would not work properly",
-            toggle: {
-              value: "necessary",
-              enabled: true,
-              readonly: true, // cookie categories with readonly=true are all treated as "necessary cookies"
-            },
-          },
-          {
-            title: "Performance and Analytics cookies",
-            description:
-              "These cookies allow the website to remember the choices you have made in the past",
-            toggle: {
-              value: "analytics", // there are no default categories => you specify them
-              enabled: false,
-              readonly: false,
-            },
-            cookie_table: [
-              {
-                col1: "^_ga",
-                col2: "google.com",
-                col3: "2 years",
-                col4: "description ...",
-                is_regex: true,
-              },
-              {
-                col1: "_gid",
-                col2: "google.com",
-                col3: "1 day",
-                col4: "description ...",
-              },
-            ],
-          },
-          {
-            title: "Advertisement and Targeting cookies",
-            description:
-              "These cookies collect information about how you use the website, which pages you visited and which links you clicked on. All of the data is anonymized and cannot be used to identify you",
-            toggle: {
-              value: "targeting",
-              enabled: false,
-              readonly: false,
-            },
-          },
-          {
-            title: "More information",
-            description:
-              'For any queries in relation to my policy on cookies and your choices, please <a class="cc-link" href="https://orestbida.com/contact">contact me</a>.',
-          },
-        ],
-      },
+    onAccept: function (cookie) {
+        console.log("onAccept fired ...");
     },
-  },
+
+    onChange: function (cookie, changed_preferences) {
+        console.log("onChange fired ...");
+    },
+
+    languages: {
+        en: {
+            consent_modal: {
+                title: cookie + " We use cookies! ",
+                description:
+                    'Hi, this website uses essential cookies to ensure its proper operation and tracking cookies to understand how you interact with it. The latter will be set only after consent. <button type="button" data-cc="c-settings" class="cc-link">Let me choose</button>',
+                primary_btn: {
+                    text: "Accept all",
+                    role: "accept_all", // 'accept_selected' or 'accept_all'
+                },
+                secondary_btn: {
+                    text: "Reject all",
+                    role: "accept_necessary", // 'settings' or 'accept_necessary'
+                },
+                imprint_link: {
+                    // 'optional to display imprint link on the modal or remove it'
+                    text: "imprint",
+                    url: "/imprint.html",
+                },
+                privacy_policy_link: {
+                    // 'optional to display privacy policy link on the modal or remove it'
+                    text: "privacy policy",
+                    url: "/privacy.html",
+                },
+            },
+            settings_modal: {
+                title: logo,
+                save_settings_btn: "Save settings",
+                accept_all_btn: "Accept all",
+                reject_all_btn: "Reject all",
+                close_btn_label: "Close",
+                cookie_table_headers: [
+                    { col1: "Name" },
+                    { col2: "Domain" },
+                    { col3: "Expiration" },
+                    { col4: "Description" },
+                ],
+                blocks: [
+                    {
+                        title: "Cookie usage 📢",
+                        description:
+                            'I use cookies to ensure the basic functionalities of the website and to enhance your online experience. You can choose for each category to opt-in/out whenever you want. For more details relative to cookies and other sensitive data, please read the full <a href="#" class="cc-link">privacy policy</a>.',
+                    },
+                    {
+                        title: "Strictly necessary cookies",
+                        description:
+                            "These cookies are essential for the proper functioning of my website. Without these cookies, the website would not work properly",
+                        toggle: {
+                            value: "necessary",
+                            enabled: true,
+                            readonly: true, // cookie categories with readonly=true are all treated as "necessary cookies"
+                        },
+                    },
+                    {
+                        title: "Performance and Analytics cookies",
+                        description:
+                            "These cookies allow the website to remember the choices you have made in the past",
+                        toggle: {
+                            value: "analytics", // there are no default categories => you specify them
+                            enabled: false,
+                            readonly: false,
+                        },
+                        cookie_table: [
+                            {
+                                col1: "^_ga",
+                                col2: "google.com",
+                                col3: "2 years",
+                                col4: "description ...",
+                                is_regex: true,
+                            },
+                            {
+                                col1: "_gid",
+                                col2: "google.com",
+                                col3: "1 day",
+                                col4: "description ...",
+                            },
+                        ],
+                    },
+                    {
+                        title: "Advertisement and Targeting cookies",
+                        description:
+                            "These cookies collect information about how you use the website, which pages you visited and which links you clicked on. All of the data is anonymized and cannot be used to identify you",
+                        toggle: {
+                            value: "targeting",
+                            enabled: false,
+                            readonly: false,
+                        },
+                    },
+                    {
+                        title: "More information",
+                        description:
+                            'For any queries in relation to my policy on cookies and your choices, please <a class="cc-link" href="https://orestbida.com/contact">contact me</a>.',
+                    },
+                ],
+            },
+        },
+    },
 });

--- a/demo/demo_basic/cookieconsent-init.js
+++ b/demo/demo_basic/cookieconsent-init.js
@@ -4,13 +4,13 @@ var cc = initCookieConsent();
 // microsoft logo
 var logo =
     '<svg style="width: 110px; height: 30px; display: block;" xmlns="http://www.w3.org/2000/svg" xml:space="preserve" viewBox="0 0 337.6 72"><path fill="#737373" d="M140.4 14.4v43.2h-7.5V23.7h-.1l-13.4 33.9h-5l-13.7-33.9h-.1v33.9h-6.9V14.4h10.8l12.4 32h.2l13.1-32h10.2zm6.2 3.3c0-1.2.4-2.2 1.3-3 .9-.8 1.9-1.2 3.1-1.2 1.3 0 2.4.4 3.2 1.2s1.3 1.8 1.3 3-.4 2.2-1.3 3c-.9.8-1.9 1.2-3.2 1.2s-2.3-.4-3.1-1.2c-.8-.9-1.3-1.9-1.3-3zm8.1 8.9v31h-7.3v-31h7.3zm22.1 25.7c1.1 0 2.3-.2 3.6-.8 1.3-.5 2.5-1.2 3.6-2v6.8c-1.2.7-2.5 1.2-4 1.5-1.5.3-3.1.5-4.9.5-4.6 0-8.3-1.4-11.1-4.3-2.9-2.9-4.3-6.6-4.3-11 0-5 1.5-9.1 4.4-12.3 2.9-3.2 7-4.8 12.4-4.8 1.4 0 2.8.2 4.1.5 1.4.3 2.5.8 3.3 1.2v7c-1.1-.8-2.3-1.5-3.4-1.9-1.2-.4-2.4-.7-3.6-.7-2.9 0-5.2.9-7 2.8s-2.6 4.4-2.6 7.6c0 3.1.9 5.6 2.6 7.3 1.7 1.7 4 2.6 6.9 2.6zm27.9-26.2a8.08 8.08 0 0 1 2.8.4v7.4c-.4-.3-.9-.6-1.7-.8s-1.6-.4-2.7-.4c-1.8 0-3.3.8-4.5 2.3s-1.9 3.8-1.9 7v15.6h-7.3v-31h7.3v4.9h.1c.7-1.7 1.7-3 3-4 1.4-.9 3-1.4 4.9-1.4zm3.2 16.5c0-5.1 1.5-9.2 4.3-12.2 2.9-3 6.9-4.5 12-4.5 4.8 0 8.6 1.4 11.3 4.3s4.1 6.8 4.1 11.7c0 5-1.5 9-4.3 12-2.9 3-6.8 4.5-11.8 4.5-4.8 0-8.6-1.4-11.4-4.2-2.8-2.9-4.2-6.8-4.2-11.6zm7.6-.3c0 3.2.7 5.7 2.2 7.4s3.6 2.6 6.3 2.6c2.6 0 4.7-.8 6.1-2.6 1.4-1.7 2.1-4.2 2.1-7.6 0-3.3-.7-5.8-2.1-7.6-1.4-1.7-3.5-2.6-6-2.6-2.7 0-4.7.9-6.2 2.7-1.7 1.9-2.4 4.4-2.4 7.7zm35-7.5c0 1 .3 1.9 1 2.5.7.6 2.1 1.3 4.4 2.2 2.9 1.2 5 2.5 6.1 3.9a8.1 8.1 0 0 1 1.8 5.3c0 2.9-1.1 5.2-3.4 7-2.2 1.8-5.3 2.6-9.1 2.6-1.3 0-2.7-.2-4.3-.5-1.6-.3-2.9-.7-4-1.2v-7.2c1.3.9 2.8 1.7 4.3 2.2 1.5.5 2.9.8 4.2.8 1.6 0 2.9-.2 3.6-.7.8-.5 1.2-1.2 1.2-2.3 0-1-.4-1.8-1.2-2.6-.8-.7-2.4-1.5-4.6-2.4-2.7-1.1-4.6-2.4-5.7-3.8s-1.7-3.2-1.7-5.4c0-2.8 1.1-5.1 3.3-6.9 2.2-1.8 5.1-2.7 8.6-2.7 1.1 0 2.3.1 3.6.4s2.5.6 3.4.9V34c-1-.6-2.1-1.2-3.4-1.7-1.3-.5-2.6-.7-3.8-.7-1.4 0-2.5.3-3.2.8-.7.7-1.1 1.4-1.1 2.4zm16.4 7.8c0-5.1 1.5-9.2 4.3-12.2 2.9-3 6.9-4.5 12-4.5 4.8 0 8.6 1.4 11.3 4.3s4.1 6.8 4.1 11.7c0 5-1.5 9-4.3 12-2.9 3-6.8 4.5-11.8 4.5-4.8 0-8.6-1.4-11.4-4.2-2.7-2.9-4.2-6.8-4.2-11.6zm7.6-.3c0 3.2.7 5.7 2.2 7.4s3.6 2.6 6.3 2.6c2.6 0 4.7-.8 6.1-2.6 1.4-1.7 2.1-4.2 2.1-7.6 0-3.3-.7-5.8-2.1-7.6-1.4-1.7-3.5-2.6-6-2.6-2.7 0-4.7.9-6.2 2.7-1.6 1.9-2.4 4.4-2.4 7.7zm48.4-9.7H312v25h-7.4v-25h-5.2v-6h5.2v-4.3c0-3.2 1.1-5.9 3.2-8s4.8-3.1 8.1-3.1c.9 0 1.7.1 2.4.1s1.3.2 1.8.4V18c-.2-.1-.7-.3-1.3-.5-.6-.2-1.3-.3-2.1-.3-1.5 0-2.7.5-3.5 1.4-.8.9-1.2 2.4-1.2 4.2v3.7h10.9v-7l7.3-2.2v9.2h7.4v6h-7.4V47c0 1.9.4 3.2 1 4 .7.8 1.8 1.2 3.3 1.2.4 0 .9-.1 1.5-.3.6-.2 1.1-.4 1.5-.7v6c-.5.3-1.2.5-2.3.7-1.1.2-2.1.3-3.2.3-3.1 0-5.4-.8-6.9-2.4-1.5-1.6-2.3-4.1-2.3-7.4l.1-15.8z"/><path fill="#f25022" d="M0 0h34.2v34.2H0z"/><path fill="#7fba00" d="M37.8 0H72v34.2H37.8z"/><path fill="#00a4ef" d="M0 37.8h34.2V72H0z"/><path fill="#ffb900" d="M37.8 37.8H72V72H37.8z"/></svg>';
-var cookie = "🍪";
+var cookie = '🍪';
 
 // run plugin with config object
 cc.run({
-    current_lang: "en",
+    current_lang: 'en',
     autoclear_cookies: true, // default: false
-    cookie_name: "cc_cookie_demo1", // default: 'cc_cookie'
+    cookie_name: 'cc_cookie_demo1', // default: 'cc_cookie'
     cookie_expiration: 365, // default: 182
     page_scripts: true, // default: false
 
@@ -28,121 +28,111 @@ cc.run({
 
     gui_options: {
         consent_modal: {
-            layout: "bar", // box,cloud,bar
-            position: "bottom right", // bottom,middle,top + left,right,center
-            transition: "slide", // zoom,slide
+            layout: 'bar', // box,cloud,bar
+            position: 'bottom right', // bottom,middle,top + left,right,center
+            transition: 'slide', // zoom,slide
         },
         settings_modal: {
-            layout: "box", // box,bar
+            layout: 'box', // box,bar
             // position: 'left',                // right,left (available only if bar layout selected)
-            transition: "slide", // zoom,slide
+            transition: 'slide', // zoom,slide
         },
     },
 
     onFirstAction: function () {
-        console.log("onFirstAction fired");
+        console.log('onFirstAction fired');
     },
 
     onAccept: function (cookie) {
-        console.log("onAccept fired ...");
+        console.log('onAccept fired ...');
     },
 
     onChange: function (cookie, changed_preferences) {
-        console.log("onChange fired ...");
+        console.log('onChange fired ...');
     },
 
     languages: {
         en: {
             consent_modal: {
-                title: cookie + " We use cookies! ",
-                description:
-                    'Hi, this website uses essential cookies to ensure its proper operation and tracking cookies to understand how you interact with it. The latter will be set only after consent. <button type="button" data-cc="c-settings" class="cc-link">Let me choose</button>',
+                title: cookie + ' We use cookies! ',
+                description: 'Hi, this website uses essential cookies to ensure its proper operation and tracking cookies to understand how you interact with it. The latter will be set only after consent. <button type="button" data-cc="c-settings" class="cc-link">Let me choose</button>',
                 primary_btn: {
-                    text: "Accept all",
-                    role: "accept_all", // 'accept_selected' or 'accept_all'
+                    text: 'Accept all',
+                    role: 'accept_all', // 'accept_selected' or 'accept_all'
                 },
                 secondary_btn: {
-                    text: "Reject all",
-                    role: "accept_necessary", // 'settings' or 'accept_necessary'
+                    text: 'Reject all',
+                    role: 'accept_necessary', // 'settings' or 'accept_necessary'
                 },
                 imprint_link: {
                     // 'optional to display imprint link on the modal or remove it'
-                    text: "imprint",
-                    url: "/imprint.html",
+                    text: 'imprint',
+                    url: '/imprint.html',
                 },
                 privacy_policy_link: {
                     // 'optional to display privacy policy link on the modal or remove it'
-                    text: "privacy policy",
-                    url: "/privacy.html",
+                    text: 'privacy policy',
+                    url: '/privacy.html',
                 },
             },
             settings_modal: {
                 title: logo,
-                save_settings_btn: "Save settings",
-                accept_all_btn: "Accept all",
-                reject_all_btn: "Reject all",
-                close_btn_label: "Close",
-                cookie_table_headers: [
-                    { col1: "Name" },
-                    { col2: "Domain" },
-                    { col3: "Expiration" },
-                    { col4: "Description" },
-                ],
+                save_settings_btn: 'Save settings',
+                accept_all_btn: 'Accept all',
+                reject_all_btn: 'Reject all',
+                close_btn_label: 'Close',
+                cookie_table_headers: [{ col1: 'Name' }, { col2: 'Domain' }, { col3: 'Expiration' }, { col4: 'Description' }],
                 blocks: [
                     {
-                        title: "Cookie usage 📢",
+                        title: 'Cookie usage 📢',
                         description:
                             'I use cookies to ensure the basic functionalities of the website and to enhance your online experience. You can choose for each category to opt-in/out whenever you want. For more details relative to cookies and other sensitive data, please read the full <a href="#" class="cc-link">privacy policy</a>.',
                     },
                     {
-                        title: "Strictly necessary cookies",
-                        description:
-                            "These cookies are essential for the proper functioning of my website. Without these cookies, the website would not work properly",
+                        title: 'Strictly necessary cookies',
+                        description: 'These cookies are essential for the proper functioning of my website. Without these cookies, the website would not work properly',
                         toggle: {
-                            value: "necessary",
+                            value: 'necessary',
                             enabled: true,
                             readonly: true, // cookie categories with readonly=true are all treated as "necessary cookies"
                         },
                     },
                     {
-                        title: "Performance and Analytics cookies",
-                        description:
-                            "These cookies allow the website to remember the choices you have made in the past",
+                        title: 'Performance and Analytics cookies',
+                        description: 'These cookies allow the website to remember the choices you have made in the past',
                         toggle: {
-                            value: "analytics", // there are no default categories => you specify them
+                            value: 'analytics', // there are no default categories => you specify them
                             enabled: false,
                             readonly: false,
                         },
                         cookie_table: [
                             {
-                                col1: "^_ga",
-                                col2: "google.com",
-                                col3: "2 years",
-                                col4: "description ...",
+                                col1: '^_ga',
+                                col2: 'google.com',
+                                col3: '2 years',
+                                col4: 'description ...',
                                 is_regex: true,
                             },
                             {
-                                col1: "_gid",
-                                col2: "google.com",
-                                col3: "1 day",
-                                col4: "description ...",
+                                col1: '_gid',
+                                col2: 'google.com',
+                                col3: '1 day',
+                                col4: 'description ...',
                             },
                         ],
                     },
                     {
-                        title: "Advertisement and Targeting cookies",
-                        description:
-                            "These cookies collect information about how you use the website, which pages you visited and which links you clicked on. All of the data is anonymized and cannot be used to identify you",
+                        title: 'Advertisement and Targeting cookies',
+                        description: 'These cookies collect information about how you use the website, which pages you visited and which links you clicked on. All of the data is anonymized and cannot be used to identify you',
                         toggle: {
-                            value: "targeting",
+                            value: 'targeting',
                             enabled: false,
                             readonly: false,
                         },
                     },
                     {
-                        title: "More information",
-                        description:
-                            'For any queries in relation to my policy on cookies and your choices, please <a class="cc-link" href="https://orestbida.com/contact">contact me</a>.',
+                        title: 'More information',
+                        description: 'For any queries in relation to my policy on cookies and your choices, please <a class="cc-link" href="https://orestbida.com/contact">contact me</a>.',
                     },
                 ],
             },

--- a/demo/demo_basic/cookieconsent-init.js
+++ b/demo/demo_basic/cookieconsent-init.js
@@ -28,7 +28,7 @@ cc.run({
 
   gui_options: {
     consent_modal: {
-      layout: "cloud", // box,cloud,bar
+      layout: "bar", // box,cloud,bar
       position: "bottom right", // bottom,middle,top + left,right,center
       transition: "slide", // zoom,slide
     },

--- a/demo/demo_basic/cookieconsent-init.js
+++ b/demo/demo_basic/cookieconsent-init.js
@@ -65,6 +65,16 @@ cc.run({
           text: "Reject all",
           role: "accept_necessary", // 'settings' or 'accept_necessary'
         },
+        imprint_link: {
+          // 'optional to display imprint link on the modal or remove it'
+          text: "imprint",
+          url: "/imprint.html",
+        },
+        privacy_policy_link: {
+          // 'optional to display privacy policy link on the modal or remove it'
+          text: "privacy policy",
+          url: "/privacy.html",
+        },
       },
       settings_modal: {
         title: logo,

--- a/demo/demo_basic/cookieconsent-init.js
+++ b/demo/demo_basic/cookieconsent-init.js
@@ -2,130 +2,140 @@
 var cc = initCookieConsent();
 
 // microsoft logo
-var logo = '<svg style="width: 110px; height: 30px; display: block;" xmlns="http://www.w3.org/2000/svg" xml:space="preserve" viewBox="0 0 337.6 72"><path fill="#737373" d="M140.4 14.4v43.2h-7.5V23.7h-.1l-13.4 33.9h-5l-13.7-33.9h-.1v33.9h-6.9V14.4h10.8l12.4 32h.2l13.1-32h10.2zm6.2 3.3c0-1.2.4-2.2 1.3-3 .9-.8 1.9-1.2 3.1-1.2 1.3 0 2.4.4 3.2 1.2s1.3 1.8 1.3 3-.4 2.2-1.3 3c-.9.8-1.9 1.2-3.2 1.2s-2.3-.4-3.1-1.2c-.8-.9-1.3-1.9-1.3-3zm8.1 8.9v31h-7.3v-31h7.3zm22.1 25.7c1.1 0 2.3-.2 3.6-.8 1.3-.5 2.5-1.2 3.6-2v6.8c-1.2.7-2.5 1.2-4 1.5-1.5.3-3.1.5-4.9.5-4.6 0-8.3-1.4-11.1-4.3-2.9-2.9-4.3-6.6-4.3-11 0-5 1.5-9.1 4.4-12.3 2.9-3.2 7-4.8 12.4-4.8 1.4 0 2.8.2 4.1.5 1.4.3 2.5.8 3.3 1.2v7c-1.1-.8-2.3-1.5-3.4-1.9-1.2-.4-2.4-.7-3.6-.7-2.9 0-5.2.9-7 2.8s-2.6 4.4-2.6 7.6c0 3.1.9 5.6 2.6 7.3 1.7 1.7 4 2.6 6.9 2.6zm27.9-26.2a8.08 8.08 0 0 1 2.8.4v7.4c-.4-.3-.9-.6-1.7-.8s-1.6-.4-2.7-.4c-1.8 0-3.3.8-4.5 2.3s-1.9 3.8-1.9 7v15.6h-7.3v-31h7.3v4.9h.1c.7-1.7 1.7-3 3-4 1.4-.9 3-1.4 4.9-1.4zm3.2 16.5c0-5.1 1.5-9.2 4.3-12.2 2.9-3 6.9-4.5 12-4.5 4.8 0 8.6 1.4 11.3 4.3s4.1 6.8 4.1 11.7c0 5-1.5 9-4.3 12-2.9 3-6.8 4.5-11.8 4.5-4.8 0-8.6-1.4-11.4-4.2-2.8-2.9-4.2-6.8-4.2-11.6zm7.6-.3c0 3.2.7 5.7 2.2 7.4s3.6 2.6 6.3 2.6c2.6 0 4.7-.8 6.1-2.6 1.4-1.7 2.1-4.2 2.1-7.6 0-3.3-.7-5.8-2.1-7.6-1.4-1.7-3.5-2.6-6-2.6-2.7 0-4.7.9-6.2 2.7-1.7 1.9-2.4 4.4-2.4 7.7zm35-7.5c0 1 .3 1.9 1 2.5.7.6 2.1 1.3 4.4 2.2 2.9 1.2 5 2.5 6.1 3.9a8.1 8.1 0 0 1 1.8 5.3c0 2.9-1.1 5.2-3.4 7-2.2 1.8-5.3 2.6-9.1 2.6-1.3 0-2.7-.2-4.3-.5-1.6-.3-2.9-.7-4-1.2v-7.2c1.3.9 2.8 1.7 4.3 2.2 1.5.5 2.9.8 4.2.8 1.6 0 2.9-.2 3.6-.7.8-.5 1.2-1.2 1.2-2.3 0-1-.4-1.8-1.2-2.6-.8-.7-2.4-1.5-4.6-2.4-2.7-1.1-4.6-2.4-5.7-3.8s-1.7-3.2-1.7-5.4c0-2.8 1.1-5.1 3.3-6.9 2.2-1.8 5.1-2.7 8.6-2.7 1.1 0 2.3.1 3.6.4s2.5.6 3.4.9V34c-1-.6-2.1-1.2-3.4-1.7-1.3-.5-2.6-.7-3.8-.7-1.4 0-2.5.3-3.2.8-.7.7-1.1 1.4-1.1 2.4zm16.4 7.8c0-5.1 1.5-9.2 4.3-12.2 2.9-3 6.9-4.5 12-4.5 4.8 0 8.6 1.4 11.3 4.3s4.1 6.8 4.1 11.7c0 5-1.5 9-4.3 12-2.9 3-6.8 4.5-11.8 4.5-4.8 0-8.6-1.4-11.4-4.2-2.7-2.9-4.2-6.8-4.2-11.6zm7.6-.3c0 3.2.7 5.7 2.2 7.4s3.6 2.6 6.3 2.6c2.6 0 4.7-.8 6.1-2.6 1.4-1.7 2.1-4.2 2.1-7.6 0-3.3-.7-5.8-2.1-7.6-1.4-1.7-3.5-2.6-6-2.6-2.7 0-4.7.9-6.2 2.7-1.6 1.9-2.4 4.4-2.4 7.7zm48.4-9.7H312v25h-7.4v-25h-5.2v-6h5.2v-4.3c0-3.2 1.1-5.9 3.2-8s4.8-3.1 8.1-3.1c.9 0 1.7.1 2.4.1s1.3.2 1.8.4V18c-.2-.1-.7-.3-1.3-.5-.6-.2-1.3-.3-2.1-.3-1.5 0-2.7.5-3.5 1.4-.8.9-1.2 2.4-1.2 4.2v3.7h10.9v-7l7.3-2.2v9.2h7.4v6h-7.4V47c0 1.9.4 3.2 1 4 .7.8 1.8 1.2 3.3 1.2.4 0 .9-.1 1.5-.3.6-.2 1.1-.4 1.5-.7v6c-.5.3-1.2.5-2.3.7-1.1.2-2.1.3-3.2.3-3.1 0-5.4-.8-6.9-2.4-1.5-1.6-2.3-4.1-2.3-7.4l.1-15.8z"/><path fill="#f25022" d="M0 0h34.2v34.2H0z"/><path fill="#7fba00" d="M37.8 0H72v34.2H37.8z"/><path fill="#00a4ef" d="M0 37.8h34.2V72H0z"/><path fill="#ffb900" d="M37.8 37.8H72V72H37.8z"/></svg>';
-var cookie = '🍪';
+var logo =
+  '<svg style="width: 110px; height: 30px; display: block;" xmlns="http://www.w3.org/2000/svg" xml:space="preserve" viewBox="0 0 337.6 72"><path fill="#737373" d="M140.4 14.4v43.2h-7.5V23.7h-.1l-13.4 33.9h-5l-13.7-33.9h-.1v33.9h-6.9V14.4h10.8l12.4 32h.2l13.1-32h10.2zm6.2 3.3c0-1.2.4-2.2 1.3-3 .9-.8 1.9-1.2 3.1-1.2 1.3 0 2.4.4 3.2 1.2s1.3 1.8 1.3 3-.4 2.2-1.3 3c-.9.8-1.9 1.2-3.2 1.2s-2.3-.4-3.1-1.2c-.8-.9-1.3-1.9-1.3-3zm8.1 8.9v31h-7.3v-31h7.3zm22.1 25.7c1.1 0 2.3-.2 3.6-.8 1.3-.5 2.5-1.2 3.6-2v6.8c-1.2.7-2.5 1.2-4 1.5-1.5.3-3.1.5-4.9.5-4.6 0-8.3-1.4-11.1-4.3-2.9-2.9-4.3-6.6-4.3-11 0-5 1.5-9.1 4.4-12.3 2.9-3.2 7-4.8 12.4-4.8 1.4 0 2.8.2 4.1.5 1.4.3 2.5.8 3.3 1.2v7c-1.1-.8-2.3-1.5-3.4-1.9-1.2-.4-2.4-.7-3.6-.7-2.9 0-5.2.9-7 2.8s-2.6 4.4-2.6 7.6c0 3.1.9 5.6 2.6 7.3 1.7 1.7 4 2.6 6.9 2.6zm27.9-26.2a8.08 8.08 0 0 1 2.8.4v7.4c-.4-.3-.9-.6-1.7-.8s-1.6-.4-2.7-.4c-1.8 0-3.3.8-4.5 2.3s-1.9 3.8-1.9 7v15.6h-7.3v-31h7.3v4.9h.1c.7-1.7 1.7-3 3-4 1.4-.9 3-1.4 4.9-1.4zm3.2 16.5c0-5.1 1.5-9.2 4.3-12.2 2.9-3 6.9-4.5 12-4.5 4.8 0 8.6 1.4 11.3 4.3s4.1 6.8 4.1 11.7c0 5-1.5 9-4.3 12-2.9 3-6.8 4.5-11.8 4.5-4.8 0-8.6-1.4-11.4-4.2-2.8-2.9-4.2-6.8-4.2-11.6zm7.6-.3c0 3.2.7 5.7 2.2 7.4s3.6 2.6 6.3 2.6c2.6 0 4.7-.8 6.1-2.6 1.4-1.7 2.1-4.2 2.1-7.6 0-3.3-.7-5.8-2.1-7.6-1.4-1.7-3.5-2.6-6-2.6-2.7 0-4.7.9-6.2 2.7-1.7 1.9-2.4 4.4-2.4 7.7zm35-7.5c0 1 .3 1.9 1 2.5.7.6 2.1 1.3 4.4 2.2 2.9 1.2 5 2.5 6.1 3.9a8.1 8.1 0 0 1 1.8 5.3c0 2.9-1.1 5.2-3.4 7-2.2 1.8-5.3 2.6-9.1 2.6-1.3 0-2.7-.2-4.3-.5-1.6-.3-2.9-.7-4-1.2v-7.2c1.3.9 2.8 1.7 4.3 2.2 1.5.5 2.9.8 4.2.8 1.6 0 2.9-.2 3.6-.7.8-.5 1.2-1.2 1.2-2.3 0-1-.4-1.8-1.2-2.6-.8-.7-2.4-1.5-4.6-2.4-2.7-1.1-4.6-2.4-5.7-3.8s-1.7-3.2-1.7-5.4c0-2.8 1.1-5.1 3.3-6.9 2.2-1.8 5.1-2.7 8.6-2.7 1.1 0 2.3.1 3.6.4s2.5.6 3.4.9V34c-1-.6-2.1-1.2-3.4-1.7-1.3-.5-2.6-.7-3.8-.7-1.4 0-2.5.3-3.2.8-.7.7-1.1 1.4-1.1 2.4zm16.4 7.8c0-5.1 1.5-9.2 4.3-12.2 2.9-3 6.9-4.5 12-4.5 4.8 0 8.6 1.4 11.3 4.3s4.1 6.8 4.1 11.7c0 5-1.5 9-4.3 12-2.9 3-6.8 4.5-11.8 4.5-4.8 0-8.6-1.4-11.4-4.2-2.7-2.9-4.2-6.8-4.2-11.6zm7.6-.3c0 3.2.7 5.7 2.2 7.4s3.6 2.6 6.3 2.6c2.6 0 4.7-.8 6.1-2.6 1.4-1.7 2.1-4.2 2.1-7.6 0-3.3-.7-5.8-2.1-7.6-1.4-1.7-3.5-2.6-6-2.6-2.7 0-4.7.9-6.2 2.7-1.6 1.9-2.4 4.4-2.4 7.7zm48.4-9.7H312v25h-7.4v-25h-5.2v-6h5.2v-4.3c0-3.2 1.1-5.9 3.2-8s4.8-3.1 8.1-3.1c.9 0 1.7.1 2.4.1s1.3.2 1.8.4V18c-.2-.1-.7-.3-1.3-.5-.6-.2-1.3-.3-2.1-.3-1.5 0-2.7.5-3.5 1.4-.8.9-1.2 2.4-1.2 4.2v3.7h10.9v-7l7.3-2.2v9.2h7.4v6h-7.4V47c0 1.9.4 3.2 1 4 .7.8 1.8 1.2 3.3 1.2.4 0 .9-.1 1.5-.3.6-.2 1.1-.4 1.5-.7v6c-.5.3-1.2.5-2.3.7-1.1.2-2.1.3-3.2.3-3.1 0-5.4-.8-6.9-2.4-1.5-1.6-2.3-4.1-2.3-7.4l.1-15.8z"/><path fill="#f25022" d="M0 0h34.2v34.2H0z"/><path fill="#7fba00" d="M37.8 0H72v34.2H37.8z"/><path fill="#00a4ef" d="M0 37.8h34.2V72H0z"/><path fill="#ffb900" d="M37.8 37.8H72V72H37.8z"/></svg>';
+var cookie = "🍪";
 
 // run plugin with config object
 cc.run({
-    current_lang : 'en',
-    autoclear_cookies : true,                   // default: false
-    cookie_name: 'cc_cookie_demo1',             // default: 'cc_cookie'
-    cookie_expiration : 365,                    // default: 182
-    page_scripts: true,                         // default: false
+  current_lang: "en",
+  autoclear_cookies: true, // default: false
+  cookie_name: "cc_cookie_demo1", // default: 'cc_cookie'
+  cookie_expiration: 365, // default: 182
+  page_scripts: true, // default: false
 
-    // auto_language: null,                     // default: null; could also be 'browser' or 'document'
-    // autorun: true,                           // default: true
-    // delay: 0,                                // default: 0
-    // force_consent: false,
-    // hide_from_bots: false,                   // default: false
-    // remove_cookie_tables: false              // default: false
-    // cookie_domain: location.hostname,        // default: current domain
-    // cookie_path: "/",                        // default: root
-    // cookie_same_site: "Lax",
-    // use_rfc_cookie: false,                   // default: false
-    // revision: 0,                             // default: 0
+  // auto_language: null,                     // default: null; could also be 'browser' or 'document'
+  // autorun: true,                           // default: true
+  // delay: 0,                                // default: 0
+  // force_consent: false,
+  // hide_from_bots: false,                   // default: false
+  // remove_cookie_tables: false              // default: false
+  // cookie_domain: location.hostname,        // default: current domain
+  // cookie_path: "/",                        // default: root
+  // cookie_same_site: "Lax",
+  // use_rfc_cookie: false,                   // default: false
+  // revision: 0,                             // default: 0
 
-    gui_options: {
-        consent_modal: {
-            layout: 'box',                      // box,cloud,bar
-            position: 'bottom right',           // bottom,middle,top + left,right,center
-            transition: 'slide'                 // zoom,slide
+  gui_options: {
+    consent_modal: {
+      layout: "cloud", // box,cloud,bar
+      position: "bottom right", // bottom,middle,top + left,right,center
+      transition: "slide", // zoom,slide
+    },
+    settings_modal: {
+      layout: "box", // box,bar
+      // position: 'left',                // right,left (available only if bar layout selected)
+      transition: "slide", // zoom,slide
+    },
+  },
+
+  onFirstAction: function () {
+    console.log("onFirstAction fired");
+  },
+
+  onAccept: function (cookie) {
+    console.log("onAccept fired ...");
+  },
+
+  onChange: function (cookie, changed_preferences) {
+    console.log("onChange fired ...");
+  },
+
+  languages: {
+    en: {
+      consent_modal: {
+        title: cookie + " We use cookies! ",
+        description:
+          'Hi, this website uses essential cookies to ensure its proper operation and tracking cookies to understand how you interact with it. The latter will be set only after consent. <button type="button" data-cc="c-settings" class="cc-link">Let me choose</button>',
+        primary_btn: {
+          text: "Accept all",
+          role: "accept_all", // 'accept_selected' or 'accept_all'
         },
-        settings_modal: {
-            layout: 'box',                      // box,bar
-            // position: 'left',                // right,left (available only if bar layout selected)
-            transition: 'slide'                 // zoom,slide
-        }
-    },
-
-    onFirstAction: function(){
-        console.log('onFirstAction fired');
-    },
-
-    onAccept: function (cookie) {
-        console.log('onAccept fired ...');
-    },
-
-    onChange: function (cookie, changed_preferences) {
-        console.log('onChange fired ...');
-    },
-
-    languages: {
-        'en': {
-            consent_modal: {
-                title: cookie + ' We use cookies! ',
-                description: 'Hi, this website uses essential cookies to ensure its proper operation and tracking cookies to understand how you interact with it. The latter will be set only after consent. <button type="button" data-cc="c-settings" class="cc-link">Let me choose</button>',
-                primary_btn: {
-                    text: 'Accept all',
-                    role: 'accept_all'              // 'accept_selected' or 'accept_all'
-                },
-                secondary_btn: {
-                    text: 'Reject all',
-                    role: 'accept_necessary'        // 'settings' or 'accept_necessary'
-                }
+        secondary_btn: {
+          text: "Reject all",
+          role: "accept_necessary", // 'settings' or 'accept_necessary'
+        },
+      },
+      settings_modal: {
+        title: logo,
+        save_settings_btn: "Save settings",
+        accept_all_btn: "Accept all",
+        reject_all_btn: "Reject all",
+        close_btn_label: "Close",
+        cookie_table_headers: [
+          { col1: "Name" },
+          { col2: "Domain" },
+          { col3: "Expiration" },
+          { col4: "Description" },
+        ],
+        blocks: [
+          {
+            title: "Cookie usage 📢",
+            description:
+              'I use cookies to ensure the basic functionalities of the website and to enhance your online experience. You can choose for each category to opt-in/out whenever you want. For more details relative to cookies and other sensitive data, please read the full <a href="#" class="cc-link">privacy policy</a>.',
+          },
+          {
+            title: "Strictly necessary cookies",
+            description:
+              "These cookies are essential for the proper functioning of my website. Without these cookies, the website would not work properly",
+            toggle: {
+              value: "necessary",
+              enabled: true,
+              readonly: true, // cookie categories with readonly=true are all treated as "necessary cookies"
             },
-            settings_modal: {
-                title: logo,
-                save_settings_btn: 'Save settings',
-                accept_all_btn: 'Accept all',
-                reject_all_btn: 'Reject all',
-                close_btn_label: 'Close',
-                cookie_table_headers: [
-                    {col1: 'Name'},
-                    {col2: 'Domain'},
-                    {col3: 'Expiration'},
-                    {col4: 'Description'}
-                ],
-                blocks: [
-                    {
-                        title: 'Cookie usage 📢',
-                        description: 'I use cookies to ensure the basic functionalities of the website and to enhance your online experience. You can choose for each category to opt-in/out whenever you want. For more details relative to cookies and other sensitive data, please read the full <a href="#" class="cc-link">privacy policy</a>.'
-                    }, {
-                        title: 'Strictly necessary cookies',
-                        description: 'These cookies are essential for the proper functioning of my website. Without these cookies, the website would not work properly',
-                        toggle: {
-                            value: 'necessary',
-                            enabled: true,
-                            readonly: true          // cookie categories with readonly=true are all treated as "necessary cookies"
-                        }
-                    }, {
-                        title: 'Performance and Analytics cookies',
-                        description: 'These cookies allow the website to remember the choices you have made in the past',
-                        toggle: {
-                            value: 'analytics',     // there are no default categories => you specify them
-                            enabled: false,
-                            readonly: false
-                        },
-                        cookie_table: [
-                            {
-                                col1: '^_ga',
-                                col2: 'google.com',
-                                col3: '2 years',
-                                col4: 'description ...',
-                                is_regex: true
-                            },
-                            {
-                                col1: '_gid',
-                                col2: 'google.com',
-                                col3: '1 day',
-                                col4: 'description ...',
-                            }
-                        ]
-                    }, {
-                        title: 'Advertisement and Targeting cookies',
-                        description: 'These cookies collect information about how you use the website, which pages you visited and which links you clicked on. All of the data is anonymized and cannot be used to identify you',
-                        toggle: {
-                            value: 'targeting',
-                            enabled: false,
-                            readonly: false
-                        }
-                    }, {
-                        title: 'More information',
-                        description: 'For any queries in relation to my policy on cookies and your choices, please <a class="cc-link" href="https://orestbida.com/contact">contact me</a>.',
-                    }
-                ]
-            }
-        }
-    }
-
+          },
+          {
+            title: "Performance and Analytics cookies",
+            description:
+              "These cookies allow the website to remember the choices you have made in the past",
+            toggle: {
+              value: "analytics", // there are no default categories => you specify them
+              enabled: false,
+              readonly: false,
+            },
+            cookie_table: [
+              {
+                col1: "^_ga",
+                col2: "google.com",
+                col3: "2 years",
+                col4: "description ...",
+                is_regex: true,
+              },
+              {
+                col1: "_gid",
+                col2: "google.com",
+                col3: "1 day",
+                col4: "description ...",
+              },
+            ],
+          },
+          {
+            title: "Advertisement and Targeting cookies",
+            description:
+              "These cookies collect information about how you use the website, which pages you visited and which links you clicked on. All of the data is anonymized and cannot be used to identify you",
+            toggle: {
+              value: "targeting",
+              enabled: false,
+              readonly: false,
+            },
+          },
+          {
+            title: "More information",
+            description:
+              'For any queries in relation to my policy on cookies and your choices, please <a class="cc-link" href="https://orestbida.com/contact">contact me</a>.',
+          },
+        ],
+      },
+    },
+  },
 });

--- a/demo/demo_basic/index.html
+++ b/demo/demo_basic/index.html
@@ -1,26 +1,45 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
+  <head>
+    <meta charset="UTF-8" />
     <title>CookieConsent demo</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="../assets/demo.css">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="../assets/demo.css" />
     <script src="../assets/demo.js" defer></script>
 
     <!-- Load plugin css -->
     <!-- <link rel="stylesheet" href="../../dist/cookieconsent.css"> -->
     <!-- Optimized css loading -->
-    <link rel="stylesheet" href="../../dist/cookieconsent.css" media="print" onload="this.media='all'">
-</head>
-<body>
-
-    <h1><a href="https://orestbida.com/demo-projects/cookieconsent/" target="_blank" class="demo-title">CookieConsent 🡥</a></h1>
+    <link
+      rel="stylesheet"
+      href="../../src/cookieconsent.css"
+      media="print"
+      onload="this.media='all'"
+    />
+  </head>
+  <body>
+    <h1>
+      <a
+        href="https://orestbida.com/demo-projects/cookieconsent/"
+        target="_blank"
+        class="demo-title"
+        >CookieConsent 🡥</a
+      >
+    </h1>
     <h2>Basic example</h2>
-    <br>
-    <p>Check your <a href="https://developer.chrome.com/docs/devtools/shortcuts/#open" target="_blank">browser's console 🡥</a> to see what's happening!</p>
+    <br />
+    <p>
+      Check your
+      <a
+        href="https://developer.chrome.com/docs/devtools/shortcuts/#open"
+        target="_blank"
+        >browser's console 🡥</a
+      >
+      to see what's happening!
+    </p>
     <button type="button" data-cc="c-settings">Cookie settings</button>
 
     <script defer src="../../src/cookieconsent.js"></script>
     <script defer src="cookieconsent-init.js"></script>
-</body>
+  </body>
 </html>

--- a/demo/demo_gtm/cookieconsent-init.js
+++ b/demo/demo_gtm/cookieconsent-init.js
@@ -1,166 +1,167 @@
 var LOREM_IPSUM =
-  "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
 
 // obtain cookieconsent plugin
 var cc = initCookieConsent();
 
 // run plugin with config object
 cc.run({
-  current_lang: "en",
-  autoclear_cookies: true, // default: false
-  cookie_name: "cc_cookie_demo2", // default: 'cc_cookie'
-  cookie_expiration: 365, // default: 182
-  page_scripts: true, // default: false
-  force_consent: true, // default: false
+    current_lang: "en",
+    autoclear_cookies: true, // default: false
+    cookie_name: "cc_cookie_demo2", // default: 'cc_cookie'
+    cookie_expiration: 365, // default: 182
+    page_scripts: true, // default: false
+    force_consent: true, // default: false
 
-  // auto_language: null,                     // default: null; could also be 'browser' or 'document'
-  // autorun: true,                           // default: true
-  // delay: 0,                                // default: 0
-  // hide_from_bots: false,                   // default: false
-  // remove_cookie_tables: false              // default: false
-  // cookie_domain: location.hostname,        // default: current domain
-  // cookie_path: '/',                        // default: root
-  // cookie_same_site: 'Lax',
-  // use_rfc_cookie: false,                   // default: false
-  // revision: 0,                             // default: 0
+    // auto_language: null,                     // default: null; could also be 'browser' or 'document'
+    // autorun: true,                           // default: true
+    // delay: 0,                                // default: 0
+    // hide_from_bots: false,                   // default: false
+    // remove_cookie_tables: false              // default: false
+    // cookie_domain: location.hostname,        // default: current domain
+    // cookie_path: '/',                        // default: root
+    // cookie_same_site: 'Lax',
+    // use_rfc_cookie: false,                   // default: false
+    // revision: 0,                             // default: 0
 
-  gui_options: {
-    consent_modal: {
-      layout: "cloud", // box,cloud,bar
-      position: "bottom center", // bottom,middle,top + left,right,center
-      transition: "slide", // zoom,slide
-    },
-    settings_modal: {
-      layout: "bar", // box,bar
-      position: "left", // right,left (available only if bar layout selected)
-      transition: "slide", // zoom,slide
-    },
-  },
-
-  onFirstAction: function () {
-    console.log("onFirstAction fired");
-  },
-
-  onAccept: function (cookie) {
-    console.log("onAccept fired!");
-  },
-
-  onChange: function (cookie, changed_preferences) {
-    console.log("onChange fired!");
-
-    // If analytics category is disabled => disable google analytics
-    if (!cc.allowedCategory("analytics")) {
-      typeof gtag === "function" &&
-        gtag("consent", "update", {
-          analytics_storage: "denied",
-        });
-    }
-  },
-
-  languages: {
-    en: {
-      consent_modal: {
-        title: "Hello traveller, it's cookie time!",
-        description:
-          'Our website uses essential cookies to ensure its proper operation and tracking cookies to understand how you interact with it. The latter will be set only after consent. <a href="#privacy-policy" class="cc-link">Privacy policy</a>',
-        primary_btn: {
-          text: "Accept all",
-          role: "accept_all", //'accept_selected' or 'accept_all'
+    gui_options: {
+        consent_modal: {
+            layout: "cloud", // box,cloud,bar
+            position: "bottom center", // bottom,middle,top + left,right,center
+            transition: "slide", // zoom,slide
         },
-        secondary_btn: {
-          text: "Preferences",
-          role: "settings", //'settings' or 'accept_necessary'
+        settings_modal: {
+            layout: "bar", // box,bar
+            position: "left", // right,left (available only if bar layout selected)
+            transition: "slide", // zoom,slide
         },
-        revision_message:
-          "<br><br> Dear user, terms and conditions have changed since the last time you visisted!",
-      },
-      settings_modal: {
-        title: "Cookie settings",
-        save_settings_btn: "Save current selection",
-        accept_all_btn: "Accept all",
-        reject_all_btn: "Reject all",
-        close_btn_label: "Close",
-        cookie_table_headers: [
-          { col1: "Name" },
-          { col2: "Domain" },
-          { col3: "Expiration" },
-        ],
-        blocks: [
-          {
-            title: "Cookie usage",
-            description:
-              LOREM_IPSUM + ' <a href="#" class="cc-link">Privacy Policy</a>.',
-          },
-          {
-            title: "Strictly necessary cookies",
-            description:
-              LOREM_IPSUM +
-              LOREM_IPSUM +
-              "<br><br>" +
-              LOREM_IPSUM +
-              LOREM_IPSUM,
-            toggle: {
-              value: "necessary",
-              enabled: true,
-              readonly: true, //cookie categories with readonly=true are all treated as "necessary cookies"
-            },
-          },
-          {
-            title: "Analytics & Performance cookies",
-            description: LOREM_IPSUM,
-            toggle: {
-              value: "analytics",
-              enabled: false,
-              readonly: false,
-            },
-            cookie_table: [
-              {
-                col1: "^_ga",
-                col2: "yourdomain.com",
-                col3: "description ...",
-                is_regex: true,
-              },
-              {
-                col1: "_gid",
-                col2: "yourdomain.com",
-                col3: "description ...",
-              },
-              {
-                col1: "_my_cookie",
-                col2: "yourdomain.com",
-                col3: "test cookie with custom path ...",
-                path: "/demo", // needed for autoclear cookies
-              },
-            ],
-          },
-          {
-            title: "Targeting & Advertising cookies",
-            description:
-              "If this category is deselected, <b>the page will reload when preferences are saved</b>... <br><br>(demo example with reload option enabled, for scripts like microsoft clarity which will re-set cookies and send beacons even after the cookies have been cleared by the cookieconsent's autoclear function)",
-            toggle: {
-              value: "targeting",
-              enabled: false,
-              readonly: false,
-              reload: "on_disable", // New option in v2.4, check readme.md
-            },
-            cookie_table: [
-              {
-                col1: "^_cl", // New option in v2.4: regex (microsoft clarity cookies)
-                col2: "yourdomain.com",
-                col3: "These cookies are set by microsoft clarity",
-                // path: '/',               // New option in v2.4
-                is_regex: true, // New option in v2.4
-              },
-            ],
-          },
-          {
-            title: "More information",
-            description:
-              LOREM_IPSUM +
-              ' <a class="cc-link" href="https://orestbida.com/contact/">Contact me</a>.',
-          },
-        ],
-      },
     },
-  },
+
+    onFirstAction: function () {
+        console.log("onFirstAction fired");
+    },
+
+    onAccept: function (cookie) {
+        console.log("onAccept fired!");
+    },
+
+    onChange: function (cookie, changed_preferences) {
+        console.log("onChange fired!");
+
+        // If analytics category is disabled => disable google analytics
+        if (!cc.allowedCategory("analytics")) {
+            typeof gtag === "function" &&
+                gtag("consent", "update", {
+                    analytics_storage: "denied",
+                });
+        }
+    },
+
+    languages: {
+        en: {
+            consent_modal: {
+                title: "Hello traveller, it's cookie time!",
+                description:
+                    'Our website uses essential cookies to ensure its proper operation and tracking cookies to understand how you interact with it. The latter will be set only after consent. <a href="#privacy-policy" class="cc-link">Privacy policy</a>',
+                primary_btn: {
+                    text: "Accept all",
+                    role: "accept_all", //'accept_selected' or 'accept_all'
+                },
+                secondary_btn: {
+                    text: "Preferences",
+                    role: "settings", //'settings' or 'accept_necessary'
+                },
+                revision_message:
+                    "<br><br> Dear user, terms and conditions have changed since the last time you visisted!",
+            },
+            settings_modal: {
+                title: "Cookie settings",
+                save_settings_btn: "Save current selection",
+                accept_all_btn: "Accept all",
+                reject_all_btn: "Reject all",
+                close_btn_label: "Close",
+                cookie_table_headers: [
+                    { col1: "Name" },
+                    { col2: "Domain" },
+                    { col3: "Expiration" },
+                ],
+                blocks: [
+                    {
+                        title: "Cookie usage",
+                        description:
+                            LOREM_IPSUM +
+                            ' <a href="#" class="cc-link">Privacy Policy</a>.',
+                    },
+                    {
+                        title: "Strictly necessary cookies",
+                        description:
+                            LOREM_IPSUM +
+                            LOREM_IPSUM +
+                            "<br><br>" +
+                            LOREM_IPSUM +
+                            LOREM_IPSUM,
+                        toggle: {
+                            value: "necessary",
+                            enabled: true,
+                            readonly: true, //cookie categories with readonly=true are all treated as "necessary cookies"
+                        },
+                    },
+                    {
+                        title: "Analytics & Performance cookies",
+                        description: LOREM_IPSUM,
+                        toggle: {
+                            value: "analytics",
+                            enabled: false,
+                            readonly: false,
+                        },
+                        cookie_table: [
+                            {
+                                col1: "^_ga",
+                                col2: "yourdomain.com",
+                                col3: "description ...",
+                                is_regex: true,
+                            },
+                            {
+                                col1: "_gid",
+                                col2: "yourdomain.com",
+                                col3: "description ...",
+                            },
+                            {
+                                col1: "_my_cookie",
+                                col2: "yourdomain.com",
+                                col3: "test cookie with custom path ...",
+                                path: "/demo", // needed for autoclear cookies
+                            },
+                        ],
+                    },
+                    {
+                        title: "Targeting & Advertising cookies",
+                        description:
+                            "If this category is deselected, <b>the page will reload when preferences are saved</b>... <br><br>(demo example with reload option enabled, for scripts like microsoft clarity which will re-set cookies and send beacons even after the cookies have been cleared by the cookieconsent's autoclear function)",
+                        toggle: {
+                            value: "targeting",
+                            enabled: false,
+                            readonly: false,
+                            reload: "on_disable", // New option in v2.4, check readme.md
+                        },
+                        cookie_table: [
+                            {
+                                col1: "^_cl", // New option in v2.4: regex (microsoft clarity cookies)
+                                col2: "yourdomain.com",
+                                col3: "These cookies are set by microsoft clarity",
+                                // path: '/',               // New option in v2.4
+                                is_regex: true, // New option in v2.4
+                            },
+                        ],
+                    },
+                    {
+                        title: "More information",
+                        description:
+                            LOREM_IPSUM +
+                            ' <a class="cc-link" href="https://orestbida.com/contact/">Contact me</a>.',
+                    },
+                ],
+            },
+        },
+    },
 });

--- a/demo/demo_gtm/cookieconsent-init.js
+++ b/demo/demo_gtm/cookieconsent-init.js
@@ -1,14 +1,13 @@
-var LOREM_IPSUM =
-    "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
+var LOREM_IPSUM = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.';
 
 // obtain cookieconsent plugin
 var cc = initCookieConsent();
 
 // run plugin with config object
 cc.run({
-    current_lang: "en",
+    current_lang: 'en',
     autoclear_cookies: true, // default: false
-    cookie_name: "cc_cookie_demo2", // default: 'cc_cookie'
+    cookie_name: 'cc_cookie_demo2', // default: 'cc_cookie'
     cookie_expiration: 365, // default: 182
     page_scripts: true, // default: false
     force_consent: true, // default: false
@@ -26,33 +25,33 @@ cc.run({
 
     gui_options: {
         consent_modal: {
-            layout: "cloud", // box,cloud,bar
-            position: "bottom center", // bottom,middle,top + left,right,center
-            transition: "slide", // zoom,slide
+            layout: 'cloud', // box,cloud,bar
+            position: 'bottom center', // bottom,middle,top + left,right,center
+            transition: 'slide', // zoom,slide
         },
         settings_modal: {
-            layout: "bar", // box,bar
-            position: "left", // right,left (available only if bar layout selected)
-            transition: "slide", // zoom,slide
+            layout: 'bar', // box,bar
+            position: 'left', // right,left (available only if bar layout selected)
+            transition: 'slide', // zoom,slide
         },
     },
 
     onFirstAction: function () {
-        console.log("onFirstAction fired");
+        console.log('onFirstAction fired');
     },
 
     onAccept: function (cookie) {
-        console.log("onAccept fired!");
+        console.log('onAccept fired!');
     },
 
     onChange: function (cookie, changed_preferences) {
-        console.log("onChange fired!");
+        console.log('onChange fired!');
 
         // If analytics category is disabled => disable google analytics
-        if (!cc.allowedCategory("analytics")) {
-            typeof gtag === "function" &&
-                gtag("consent", "update", {
-                    analytics_storage: "denied",
+        if (!cc.allowedCategory('analytics')) {
+            typeof gtag === 'function' &&
+                gtag('consent', 'update', {
+                    analytics_storage: 'denied',
                 });
         }
     },
@@ -61,104 +60,89 @@ cc.run({
         en: {
             consent_modal: {
                 title: "Hello traveller, it's cookie time!",
-                description:
-                    'Our website uses essential cookies to ensure its proper operation and tracking cookies to understand how you interact with it. The latter will be set only after consent. <a href="#privacy-policy" class="cc-link">Privacy policy</a>',
+                description: 'Our website uses essential cookies to ensure its proper operation and tracking cookies to understand how you interact with it. The latter will be set only after consent. <a href="#privacy-policy" class="cc-link">Privacy policy</a>',
                 primary_btn: {
-                    text: "Accept all",
-                    role: "accept_all", //'accept_selected' or 'accept_all'
+                    text: 'Accept all',
+                    role: 'accept_all', //'accept_selected' or 'accept_all'
                 },
                 secondary_btn: {
-                    text: "Preferences",
-                    role: "settings", //'settings' or 'accept_necessary'
+                    text: 'Preferences',
+                    role: 'settings', //'settings' or 'accept_necessary'
                 },
-                revision_message:
-                    "<br><br> Dear user, terms and conditions have changed since the last time you visisted!",
+                revision_message: '<br><br> Dear user, terms and conditions have changed since the last time you visisted!',
             },
             settings_modal: {
-                title: "Cookie settings",
-                save_settings_btn: "Save current selection",
-                accept_all_btn: "Accept all",
-                reject_all_btn: "Reject all",
-                close_btn_label: "Close",
-                cookie_table_headers: [
-                    { col1: "Name" },
-                    { col2: "Domain" },
-                    { col3: "Expiration" },
-                ],
+                title: 'Cookie settings',
+                save_settings_btn: 'Save current selection',
+                accept_all_btn: 'Accept all',
+                reject_all_btn: 'Reject all',
+                close_btn_label: 'Close',
+                cookie_table_headers: [{ col1: 'Name' }, { col2: 'Domain' }, { col3: 'Expiration' }],
                 blocks: [
                     {
-                        title: "Cookie usage",
-                        description:
-                            LOREM_IPSUM +
-                            ' <a href="#" class="cc-link">Privacy Policy</a>.',
+                        title: 'Cookie usage',
+                        description: LOREM_IPSUM + ' <a href="#" class="cc-link">Privacy Policy</a>.',
                     },
                     {
-                        title: "Strictly necessary cookies",
-                        description:
-                            LOREM_IPSUM +
-                            LOREM_IPSUM +
-                            "<br><br>" +
-                            LOREM_IPSUM +
-                            LOREM_IPSUM,
+                        title: 'Strictly necessary cookies',
+                        description: LOREM_IPSUM + LOREM_IPSUM + '<br><br>' + LOREM_IPSUM + LOREM_IPSUM,
                         toggle: {
-                            value: "necessary",
+                            value: 'necessary',
                             enabled: true,
                             readonly: true, //cookie categories with readonly=true are all treated as "necessary cookies"
                         },
                     },
                     {
-                        title: "Analytics & Performance cookies",
+                        title: 'Analytics & Performance cookies',
                         description: LOREM_IPSUM,
                         toggle: {
-                            value: "analytics",
+                            value: 'analytics',
                             enabled: false,
                             readonly: false,
                         },
                         cookie_table: [
                             {
-                                col1: "^_ga",
-                                col2: "yourdomain.com",
-                                col3: "description ...",
+                                col1: '^_ga',
+                                col2: 'yourdomain.com',
+                                col3: 'description ...',
                                 is_regex: true,
                             },
                             {
-                                col1: "_gid",
-                                col2: "yourdomain.com",
-                                col3: "description ...",
+                                col1: '_gid',
+                                col2: 'yourdomain.com',
+                                col3: 'description ...',
                             },
                             {
-                                col1: "_my_cookie",
-                                col2: "yourdomain.com",
-                                col3: "test cookie with custom path ...",
-                                path: "/demo", // needed for autoclear cookies
+                                col1: '_my_cookie',
+                                col2: 'yourdomain.com',
+                                col3: 'test cookie with custom path ...',
+                                path: '/demo', // needed for autoclear cookies
                             },
                         ],
                     },
                     {
-                        title: "Targeting & Advertising cookies",
+                        title: 'Targeting & Advertising cookies',
                         description:
                             "If this category is deselected, <b>the page will reload when preferences are saved</b>... <br><br>(demo example with reload option enabled, for scripts like microsoft clarity which will re-set cookies and send beacons even after the cookies have been cleared by the cookieconsent's autoclear function)",
                         toggle: {
-                            value: "targeting",
+                            value: 'targeting',
                             enabled: false,
                             readonly: false,
-                            reload: "on_disable", // New option in v2.4, check readme.md
+                            reload: 'on_disable', // New option in v2.4, check readme.md
                         },
                         cookie_table: [
                             {
-                                col1: "^_cl", // New option in v2.4: regex (microsoft clarity cookies)
-                                col2: "yourdomain.com",
-                                col3: "These cookies are set by microsoft clarity",
+                                col1: '^_cl', // New option in v2.4: regex (microsoft clarity cookies)
+                                col2: 'yourdomain.com',
+                                col3: 'These cookies are set by microsoft clarity',
                                 // path: '/',               // New option in v2.4
                                 is_regex: true, // New option in v2.4
                             },
                         ],
                     },
                     {
-                        title: "More information",
-                        description:
-                            LOREM_IPSUM +
-                            ' <a class="cc-link" href="https://orestbida.com/contact/">Contact me</a>.',
+                        title: 'More information',
+                        description: LOREM_IPSUM + ' <a class="cc-link" href="https://orestbida.com/contact/">Contact me</a>.',
                     },
                 ],
             },

--- a/demo/demo_gtm/cookieconsent-init.js
+++ b/demo/demo_gtm/cookieconsent-init.js
@@ -1,149 +1,166 @@
-var LOREM_IPSUM = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.';
+var LOREM_IPSUM =
+  "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
 
 // obtain cookieconsent plugin
 var cc = initCookieConsent();
 
 // run plugin with config object
 cc.run({
-    current_lang: 'en',
-    autoclear_cookies: true,                    // default: false
-    cookie_name: 'cc_cookie_demo2',             // default: 'cc_cookie'
-    cookie_expiration: 365,                     // default: 182
-    page_scripts: true,                         // default: false
-    force_consent: true,                        // default: false
+  current_lang: "en",
+  autoclear_cookies: true, // default: false
+  cookie_name: "cc_cookie_demo2", // default: 'cc_cookie'
+  cookie_expiration: 365, // default: 182
+  page_scripts: true, // default: false
+  force_consent: true, // default: false
 
-    // auto_language: null,                     // default: null; could also be 'browser' or 'document'
-    // autorun: true,                           // default: true
-    // delay: 0,                                // default: 0
-    // hide_from_bots: false,                   // default: false
-    // remove_cookie_tables: false              // default: false
-    // cookie_domain: location.hostname,        // default: current domain
-    // cookie_path: '/',                        // default: root
-    // cookie_same_site: 'Lax',
-    // use_rfc_cookie: false,                   // default: false
-    // revision: 0,                             // default: 0
+  // auto_language: null,                     // default: null; could also be 'browser' or 'document'
+  // autorun: true,                           // default: true
+  // delay: 0,                                // default: 0
+  // hide_from_bots: false,                   // default: false
+  // remove_cookie_tables: false              // default: false
+  // cookie_domain: location.hostname,        // default: current domain
+  // cookie_path: '/',                        // default: root
+  // cookie_same_site: 'Lax',
+  // use_rfc_cookie: false,                   // default: false
+  // revision: 0,                             // default: 0
 
-    gui_options: {
-        consent_modal: {
-            layout: 'cloud',                    // box,cloud,bar
-            position: 'bottom center',          // bottom,middle,top + left,right,center
-            transition: 'slide'                 // zoom,slide
-        },
-        settings_modal: {
-            layout: 'bar',                      // box,bar
-            position: 'left',                   // right,left (available only if bar layout selected)
-            transition: 'slide'                 // zoom,slide
-        }
+  gui_options: {
+    consent_modal: {
+      layout: "cloud", // box,cloud,bar
+      position: "bottom center", // bottom,middle,top + left,right,center
+      transition: "slide", // zoom,slide
     },
-
-    onFirstAction: function(){
-        console.log('onFirstAction fired');
+    settings_modal: {
+      layout: "bar", // box,bar
+      position: "left", // right,left (available only if bar layout selected)
+      transition: "slide", // zoom,slide
     },
+  },
 
-    onAccept: function (cookie) {
-        console.log('onAccept fired!')
-    },
+  onFirstAction: function () {
+    console.log("onFirstAction fired");
+  },
 
-    onChange: function (cookie, changed_preferences) {
-        console.log('onChange fired!');
+  onAccept: function (cookie) {
+    console.log("onAccept fired!");
+  },
 
-        // If analytics category is disabled => disable google analytics
-        if (!cc.allowedCategory('analytics')) {
-            typeof gtag === 'function' && gtag('consent', 'update', {
-                'analytics_storage': 'denied'
-            });
-        }
-    },
+  onChange: function (cookie, changed_preferences) {
+    console.log("onChange fired!");
 
-    languages: {
-        'en': {
-            consent_modal: {
-                title: 'Hello traveller, it\'s cookie time!',
-                description: 'Our website uses essential cookies to ensure its proper operation and tracking cookies to understand how you interact with it. The latter will be set only after consent. <a href="#privacy-policy" class="cc-link">Privacy policy</a>',
-                primary_btn: {
-                    text: 'Accept all',
-                    role: 'accept_all'      //'accept_selected' or 'accept_all'
-                },
-                secondary_btn: {
-                    text: 'Preferences',
-                    role: 'settings'       //'settings' or 'accept_necessary'
-                },
-                revision_message: '<br><br> Dear user, terms and conditions have changed since the last time you visisted!'
-            },
-            settings_modal: {
-                title: 'Cookie settings',
-                save_settings_btn: 'Save current selection',
-                accept_all_btn: 'Accept all',
-                reject_all_btn: 'Reject all',
-                close_btn_label: 'Close',
-                cookie_table_headers: [
-                    {col1: 'Name'},
-                    {col2: 'Domain'},
-                    {col3: 'Expiration'}
-                ],
-                blocks: [
-                    {
-                        title: 'Cookie usage',
-                        description: LOREM_IPSUM + ' <a href="#" class="cc-link">Privacy Policy</a>.'
-                    }, {
-                        title: 'Strictly necessary cookies',
-                        description: LOREM_IPSUM + LOREM_IPSUM + "<br><br>" + LOREM_IPSUM + LOREM_IPSUM,
-                        toggle: {
-                            value: 'necessary',
-                            enabled: true,
-                            readonly: true  //cookie categories with readonly=true are all treated as "necessary cookies"
-                        }
-                    }, {
-                        title: 'Analytics & Performance cookies',
-                        description: LOREM_IPSUM,
-                        toggle: {
-                            value: 'analytics',
-                            enabled: false,
-                            readonly: false
-                        },
-                        cookie_table: [
-                            {
-                                col1: '^_ga',
-                                col2: 'yourdomain.com',
-                                col3: 'description ...',
-                                is_regex: true
-                            },
-                            {
-                                col1: '_gid',
-                                col2: 'yourdomain.com',
-                                col3: 'description ...',
-                            },
-                            {
-                                col1: '_my_cookie',
-                                col2: 'yourdomain.com',
-                                col3: 'test cookie with custom path ...',
-                                path: '/demo'       // needed for autoclear cookies
-                            }
-                        ]
-                    }, {
-                        title: 'Targeting & Advertising cookies',
-                        description: 'If this category is deselected, <b>the page will reload when preferences are saved</b>... <br><br>(demo example with reload option enabled, for scripts like microsoft clarity which will re-set cookies and send beacons even after the cookies have been cleared by the cookieconsent\'s autoclear function)',
-                        toggle: {
-                            value: 'targeting',
-                            enabled: false,
-                            readonly: false,
-                            reload: 'on_disable'            // New option in v2.4, check readme.md
-                        },
-                        cookie_table: [
-                            {
-                                col1: '^_cl',               // New option in v2.4: regex (microsoft clarity cookies)
-                                col2: 'yourdomain.com',
-                                col3: 'These cookies are set by microsoft clarity',
-                                // path: '/',               // New option in v2.4
-                                is_regex: true              // New option in v2.4
-                            }
-                        ]
-                    }, {
-                        title: 'More information',
-                        description: LOREM_IPSUM + ' <a class="cc-link" href="https://orestbida.com/contact/">Contact me</a>.',
-                    }
-                ]
-            }
-        }
+    // If analytics category is disabled => disable google analytics
+    if (!cc.allowedCategory("analytics")) {
+      typeof gtag === "function" &&
+        gtag("consent", "update", {
+          analytics_storage: "denied",
+        });
     }
+  },
+
+  languages: {
+    en: {
+      consent_modal: {
+        title: "Hello traveller, it's cookie time!",
+        description:
+          'Our website uses essential cookies to ensure its proper operation and tracking cookies to understand how you interact with it. The latter will be set only after consent. <a href="#privacy-policy" class="cc-link">Privacy policy</a>',
+        primary_btn: {
+          text: "Accept all",
+          role: "accept_all", //'accept_selected' or 'accept_all'
+        },
+        secondary_btn: {
+          text: "Preferences",
+          role: "settings", //'settings' or 'accept_necessary'
+        },
+        revision_message:
+          "<br><br> Dear user, terms and conditions have changed since the last time you visisted!",
+      },
+      settings_modal: {
+        title: "Cookie settings",
+        save_settings_btn: "Save current selection",
+        accept_all_btn: "Accept all",
+        reject_all_btn: "Reject all",
+        close_btn_label: "Close",
+        cookie_table_headers: [
+          { col1: "Name" },
+          { col2: "Domain" },
+          { col3: "Expiration" },
+        ],
+        blocks: [
+          {
+            title: "Cookie usage",
+            description:
+              LOREM_IPSUM + ' <a href="#" class="cc-link">Privacy Policy</a>.',
+          },
+          {
+            title: "Strictly necessary cookies",
+            description:
+              LOREM_IPSUM +
+              LOREM_IPSUM +
+              "<br><br>" +
+              LOREM_IPSUM +
+              LOREM_IPSUM,
+            toggle: {
+              value: "necessary",
+              enabled: true,
+              readonly: true, //cookie categories with readonly=true are all treated as "necessary cookies"
+            },
+          },
+          {
+            title: "Analytics & Performance cookies",
+            description: LOREM_IPSUM,
+            toggle: {
+              value: "analytics",
+              enabled: false,
+              readonly: false,
+            },
+            cookie_table: [
+              {
+                col1: "^_ga",
+                col2: "yourdomain.com",
+                col3: "description ...",
+                is_regex: true,
+              },
+              {
+                col1: "_gid",
+                col2: "yourdomain.com",
+                col3: "description ...",
+              },
+              {
+                col1: "_my_cookie",
+                col2: "yourdomain.com",
+                col3: "test cookie with custom path ...",
+                path: "/demo", // needed for autoclear cookies
+              },
+            ],
+          },
+          {
+            title: "Targeting & Advertising cookies",
+            description:
+              "If this category is deselected, <b>the page will reload when preferences are saved</b>... <br><br>(demo example with reload option enabled, for scripts like microsoft clarity which will re-set cookies and send beacons even after the cookies have been cleared by the cookieconsent's autoclear function)",
+            toggle: {
+              value: "targeting",
+              enabled: false,
+              readonly: false,
+              reload: "on_disable", // New option in v2.4, check readme.md
+            },
+            cookie_table: [
+              {
+                col1: "^_cl", // New option in v2.4: regex (microsoft clarity cookies)
+                col2: "yourdomain.com",
+                col3: "These cookies are set by microsoft clarity",
+                // path: '/',               // New option in v2.4
+                is_regex: true, // New option in v2.4
+              },
+            ],
+          },
+          {
+            title: "More information",
+            description:
+              LOREM_IPSUM +
+              ' <a class="cc-link" href="https://orestbida.com/contact/">Contact me</a>.',
+          },
+        ],
+      },
+    },
+  },
 });

--- a/demo/demo_gtm/index.html
+++ b/demo/demo_gtm/index.html
@@ -1,23 +1,42 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
+  <head>
+    <meta charset="UTF-8" />
     <title>CookieConsent demo</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="../assets/demo.css">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="../assets/demo.css" />
     <script src="../assets/demo.js" defer></script>
 
     <!-- Load plugin css -->
     <!-- <link rel="stylesheet" href="../../dist/cookieconsent.css"> -->
     <!-- Optimized css loading -->
-    <link rel="stylesheet" href="../../dist/cookieconsent.css" media="print" onload="this.media='all'">
-</head>
-<body>
-
-    <h1><a href="https://orestbida.com/demo-projects/cookieconsent/" target="_blank" class="demo-title">CookieConsent 🡥</a></h1>
+    <link
+      rel="stylesheet"
+      href="../../src/cookieconsent.css"
+      media="print"
+      onload="this.media='all'"
+    />
+  </head>
+  <body>
+    <h1>
+      <a
+        href="https://orestbida.com/demo-projects/cookieconsent/"
+        target="_blank"
+        class="demo-title"
+        >CookieConsent 🡥</a
+      >
+    </h1>
     <h2>Example configuration with Google Tag Manager</h2>
-    <br>
-    <p>Check your <a href="https://developer.chrome.com/docs/devtools/shortcuts/#open" target="_blank">browser's console 🡥</a> to see what's happening!</p>
+    <br />
+    <p>
+      Check your
+      <a
+        href="https://developer.chrome.com/docs/devtools/shortcuts/#open"
+        target="_blank"
+        >browser's console 🡥</a
+      >
+      to see what's happening!
+    </p>
     <button type="button" data-cc="c-settings">Cookie settings</button>
 
     <script defer src="../../src/cookieconsent.js"></script>
@@ -31,17 +50,17 @@
     -->
 
     <script type="text/plain" data-cookiecategory="analytics">
-        console.log('analytics enabled!');
+      console.log('analytics enabled!');
     </script>
 
     <!-- INLINE GTM (replace "GTM-XXXXXXX" with your id)-->
     <script type="text/plain" data-cookiecategory="analytics">
-        // Google Tag Manager (configured with GA internally)
-        (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-        })(window,document,'script','dataLayer','GTM-XXXXXXX');
+      // Google Tag Manager (configured with GA internally)
+      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','GTM-XXXXXXX');
     </script>
-</body>
+  </body>
 </html>

--- a/demo/demo_iframemanager/cookieconsent-init.js
+++ b/demo/demo_iframemanager/cookieconsent-init.js
@@ -1,5 +1,5 @@
 var LOREM_IPSUM =
-  "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
 
 // obtain iframemanager object
 var manager = iframemanager();
@@ -9,173 +9,172 @@ var cc = initCookieConsent();
 
 // Configure with youtube embed
 manager.run({
-  currLang: "en",
-  services: {
-    youtube: {
-      embedUrl: "https://www.youtube-nocookie.com/embed/{data-id}",
-      thumbnailUrl: "https://i3.ytimg.com/vi/{data-id}/hqdefault.jpg",
-      iframe: {
-        allow:
-          "accelerometer; encrypted-media; gyroscope; picture-in-picture; fullscreen;",
-      },
-      cookie: {
-        name: "cc_youtube",
-      },
-      languages: {
-        en: {
-          notice:
-            'This content is hosted by a third party. By showing the external content you accept the <a rel="noreferrer" href="https://www.youtube.com/t/terms" title="Terms and conditions" target="_blank">terms and conditions</a> of youtube.com.',
-          loadBtn: "Load video",
-          loadAllBtn: "Don't ask again",
+    currLang: "en",
+    services: {
+        youtube: {
+            embedUrl: "https://www.youtube-nocookie.com/embed/{data-id}",
+            thumbnailUrl: "https://i3.ytimg.com/vi/{data-id}/hqdefault.jpg",
+            iframe: {
+                allow: "accelerometer; encrypted-media; gyroscope; picture-in-picture; fullscreen;",
+            },
+            cookie: {
+                name: "cc_youtube",
+            },
+            languages: {
+                en: {
+                    notice: 'This content is hosted by a third party. By showing the external content you accept the <a rel="noreferrer" href="https://www.youtube.com/t/terms" title="Terms and conditions" target="_blank">terms and conditions</a> of youtube.com.',
+                    loadBtn: "Load video",
+                    loadAllBtn: "Don't ask again",
+                },
+            },
         },
-      },
     },
-  },
 });
 
 // run plugin with config object
 cc.run({
-  current_lang: "en",
-  autoclear_cookies: true, // default: false
-  cookie_name: "cc_cookie_demo2", // default: 'cc_cookie'
-  cookie_expiration: 365, // default: 182
-  // page_scripts: false,                         // default: false
-  force_consent: true, // default: false
+    current_lang: "en",
+    autoclear_cookies: true, // default: false
+    cookie_name: "cc_cookie_demo2", // default: 'cc_cookie'
+    cookie_expiration: 365, // default: 182
+    // page_scripts: false,                         // default: false
+    force_consent: true, // default: false
 
-  // auto_language: null,                     // default: null; could also be 'browser' or 'document'
-  // autorun: true,                           // default: true
-  // delay: 0,                                // default: 0
-  // hide_from_bots: false,                   // default: false
-  // remove_cookie_tables: false              // default: false
-  // cookie_domain: location.hostname,        // default: current domain
-  // cookie_path: '/',                        // default: root
-  // cookie_same_site: 'Lax',
-  // use_rfc_cookie: false,                   // default: false
-  // revision: 0,                             // default: 0
+    // auto_language: null,                     // default: null; could also be 'browser' or 'document'
+    // autorun: true,                           // default: true
+    // delay: 0,                                // default: 0
+    // hide_from_bots: false,                   // default: false
+    // remove_cookie_tables: false              // default: false
+    // cookie_domain: location.hostname,        // default: current domain
+    // cookie_path: '/',                        // default: root
+    // cookie_same_site: 'Lax',
+    // use_rfc_cookie: false,                   // default: false
+    // revision: 0,                             // default: 0
 
-  gui_options: {
-    consent_modal: {
-      layout: "cloud", // box,cloud,bar
-      position: "bottom center", // bottom,middle,top + left,right,center
-      transition: "slide", // zoom,slide
-    },
-    settings_modal: {
-      layout: "bar", // box,bar
-      position: "left", // right,left (available only if bar layout selected)
-      transition: "slide", // zoom,slide
-    },
-  },
-
-  onFirstAction: function () {
-    console.log("onFirstAction fired");
-  },
-
-  onAccept: function () {
-    console.log("onAccept fired!");
-
-    // If analytics category is disabled => load all iframes automatically
-    if (cc.allowedCategory("analytics")) {
-      console.log("iframemanager: loading all iframes");
-      manager.acceptService("all");
-    }
-  },
-
-  onChange: function (cookie, changed_preferences) {
-    console.log("onChange fired!");
-
-    // If analytics category is disabled => ask for permission to load iframes
-    if (!cc.allowedCategory("analytics")) {
-      console.log("iframemanager: disabling all iframes");
-      manager.rejectService("all");
-    } else {
-      console.log("iframemanager: loading all iframes");
-      manager.acceptService("all");
-    }
-  },
-
-  languages: {
-    en: {
-      consent_modal: {
-        title: "Hello traveller, it's cookie time!",
-        description:
-          'Our website uses essential cookies to ensure its proper operation and tracking cookies to understand how you interact with it. The latter will be set only after consent. <a href="#privacy-policy" class="cc-link">Privacy policy</a>',
-        primary_btn: {
-          text: "Accept all",
-          role: "accept_all", //'accept_selected' or 'accept_all'
+    gui_options: {
+        consent_modal: {
+            layout: "cloud", // box,cloud,bar
+            position: "bottom center", // bottom,middle,top + left,right,center
+            transition: "slide", // zoom,slide
         },
-        secondary_btn: {
-          text: "Preferences",
-          role: "settings", //'settings' or 'accept_necessary'
+        settings_modal: {
+            layout: "bar", // box,bar
+            position: "left", // right,left (available only if bar layout selected)
+            transition: "slide", // zoom,slide
         },
-        revision_message:
-          "<br><br> Dear user, terms and conditions have changed since the last time you visisted!",
-      },
-      settings_modal: {
-        title: "Cookie settings",
-        save_settings_btn: "Save current selection",
-        accept_all_btn: "Accept all",
-        reject_all_btn: "Reject all",
-        close_btn_label: "Close",
-        cookie_table_headers: [
-          { col1: "Name" },
-          { col2: "Domain" },
-          { col3: "Expiration" },
-        ],
-        blocks: [
-          {
-            title: "Cookie usage",
-            description:
-              LOREM_IPSUM + ' <a href="#" class="cc-link">Privacy Policy</a>.',
-          },
-          {
-            title: "Strictly necessary cookies",
-            description:
-              LOREM_IPSUM +
-              LOREM_IPSUM +
-              "<br><br>" +
-              LOREM_IPSUM +
-              LOREM_IPSUM,
-            toggle: {
-              value: "necessary",
-              enabled: true,
-              readonly: true, //cookie categories with readonly=true are all treated as "necessary cookies"
-            },
-          },
-          {
-            title: "Analytics & Performance cookies",
-            description: LOREM_IPSUM,
-            toggle: {
-              value: "analytics",
-              enabled: false,
-              readonly: false,
-            },
-            cookie_table: [
-              {
-                col1: "^_ga",
-                col2: "yourdomain.com",
-                col3: "description ...",
-                is_regex: true,
-              },
-              {
-                col1: "_gid",
-                col2: "yourdomain.com",
-                col3: "description ...",
-              },
-              {
-                col1: "cc_youtube",
-                col2: "yourdomain.com",
-                col3: "Cookie set by iframemanager",
-              },
-            ],
-          },
-          {
-            title: "More information",
-            description:
-              LOREM_IPSUM +
-              ' <a class="cc-link" href="https://orestbida.com/contact/">Contact me</a>.',
-          },
-        ],
-      },
     },
-  },
+
+    onFirstAction: function () {
+        console.log("onFirstAction fired");
+    },
+
+    onAccept: function () {
+        console.log("onAccept fired!");
+
+        // If analytics category is disabled => load all iframes automatically
+        if (cc.allowedCategory("analytics")) {
+            console.log("iframemanager: loading all iframes");
+            manager.acceptService("all");
+        }
+    },
+
+    onChange: function (cookie, changed_preferences) {
+        console.log("onChange fired!");
+
+        // If analytics category is disabled => ask for permission to load iframes
+        if (!cc.allowedCategory("analytics")) {
+            console.log("iframemanager: disabling all iframes");
+            manager.rejectService("all");
+        } else {
+            console.log("iframemanager: loading all iframes");
+            manager.acceptService("all");
+        }
+    },
+
+    languages: {
+        en: {
+            consent_modal: {
+                title: "Hello traveller, it's cookie time!",
+                description:
+                    'Our website uses essential cookies to ensure its proper operation and tracking cookies to understand how you interact with it. The latter will be set only after consent. <a href="#privacy-policy" class="cc-link">Privacy policy</a>',
+                primary_btn: {
+                    text: "Accept all",
+                    role: "accept_all", //'accept_selected' or 'accept_all'
+                },
+                secondary_btn: {
+                    text: "Preferences",
+                    role: "settings", //'settings' or 'accept_necessary'
+                },
+                revision_message:
+                    "<br><br> Dear user, terms and conditions have changed since the last time you visisted!",
+            },
+            settings_modal: {
+                title: "Cookie settings",
+                save_settings_btn: "Save current selection",
+                accept_all_btn: "Accept all",
+                reject_all_btn: "Reject all",
+                close_btn_label: "Close",
+                cookie_table_headers: [
+                    { col1: "Name" },
+                    { col2: "Domain" },
+                    { col3: "Expiration" },
+                ],
+                blocks: [
+                    {
+                        title: "Cookie usage",
+                        description:
+                            LOREM_IPSUM +
+                            ' <a href="#" class="cc-link">Privacy Policy</a>.',
+                    },
+                    {
+                        title: "Strictly necessary cookies",
+                        description:
+                            LOREM_IPSUM +
+                            LOREM_IPSUM +
+                            "<br><br>" +
+                            LOREM_IPSUM +
+                            LOREM_IPSUM,
+                        toggle: {
+                            value: "necessary",
+                            enabled: true,
+                            readonly: true, //cookie categories with readonly=true are all treated as "necessary cookies"
+                        },
+                    },
+                    {
+                        title: "Analytics & Performance cookies",
+                        description: LOREM_IPSUM,
+                        toggle: {
+                            value: "analytics",
+                            enabled: false,
+                            readonly: false,
+                        },
+                        cookie_table: [
+                            {
+                                col1: "^_ga",
+                                col2: "yourdomain.com",
+                                col3: "description ...",
+                                is_regex: true,
+                            },
+                            {
+                                col1: "_gid",
+                                col2: "yourdomain.com",
+                                col3: "description ...",
+                            },
+                            {
+                                col1: "cc_youtube",
+                                col2: "yourdomain.com",
+                                col3: "Cookie set by iframemanager",
+                            },
+                        ],
+                    },
+                    {
+                        title: "More information",
+                        description:
+                            LOREM_IPSUM +
+                            ' <a class="cc-link" href="https://orestbida.com/contact/">Contact me</a>.',
+                    },
+                ],
+            },
+        },
+    },
 });

--- a/demo/demo_iframemanager/cookieconsent-init.js
+++ b/demo/demo_iframemanager/cookieconsent-init.js
@@ -1,4 +1,5 @@
-var LOREM_IPSUM = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.';
+var LOREM_IPSUM =
+  "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
 
 // obtain iframemanager object
 var manager = iframemanager();
@@ -8,158 +9,173 @@ var cc = initCookieConsent();
 
 // Configure with youtube embed
 manager.run({
-    currLang: 'en',
-    services : {
-        youtube : {
-            embedUrl: 'https://www.youtube-nocookie.com/embed/{data-id}',
-            thumbnailUrl: 'https://i3.ytimg.com/vi/{data-id}/hqdefault.jpg',
-            iframe : {
-                allow : 'accelerometer; encrypted-media; gyroscope; picture-in-picture; fullscreen;',
-            },
-            cookie : {
-                name : 'cc_youtube'
-            },
-            languages : {
-                en : {
-                    notice: 'This content is hosted by a third party. By showing the external content you accept the <a rel="noreferrer" href="https://www.youtube.com/t/terms" title="Terms and conditions" target="_blank">terms and conditions</a> of youtube.com.',
-                    loadBtn: 'Load video',
-                    loadAllBtn: 'Don\'t ask again'
-                }
-            }
-        }
-    }
+  currLang: "en",
+  services: {
+    youtube: {
+      embedUrl: "https://www.youtube-nocookie.com/embed/{data-id}",
+      thumbnailUrl: "https://i3.ytimg.com/vi/{data-id}/hqdefault.jpg",
+      iframe: {
+        allow:
+          "accelerometer; encrypted-media; gyroscope; picture-in-picture; fullscreen;",
+      },
+      cookie: {
+        name: "cc_youtube",
+      },
+      languages: {
+        en: {
+          notice:
+            'This content is hosted by a third party. By showing the external content you accept the <a rel="noreferrer" href="https://www.youtube.com/t/terms" title="Terms and conditions" target="_blank">terms and conditions</a> of youtube.com.',
+          loadBtn: "Load video",
+          loadAllBtn: "Don't ask again",
+        },
+      },
+    },
+  },
 });
 
 // run plugin with config object
 cc.run({
-    current_lang: 'en',
-    autoclear_cookies: true,                    // default: false
-    cookie_name: 'cc_cookie_demo2',             // default: 'cc_cookie'
-    cookie_expiration: 365,                     // default: 182
-    // page_scripts: false,                         // default: false
-    force_consent: true,                        // default: false
+  current_lang: "en",
+  autoclear_cookies: true, // default: false
+  cookie_name: "cc_cookie_demo2", // default: 'cc_cookie'
+  cookie_expiration: 365, // default: 182
+  // page_scripts: false,                         // default: false
+  force_consent: true, // default: false
 
-    // auto_language: null,                     // default: null; could also be 'browser' or 'document'
-    // autorun: true,                           // default: true
-    // delay: 0,                                // default: 0
-    // hide_from_bots: false,                   // default: false
-    // remove_cookie_tables: false              // default: false
-    // cookie_domain: location.hostname,        // default: current domain
-    // cookie_path: '/',                        // default: root
-    // cookie_same_site: 'Lax',
-    // use_rfc_cookie: false,                   // default: false
-    // revision: 0,                             // default: 0
+  // auto_language: null,                     // default: null; could also be 'browser' or 'document'
+  // autorun: true,                           // default: true
+  // delay: 0,                                // default: 0
+  // hide_from_bots: false,                   // default: false
+  // remove_cookie_tables: false              // default: false
+  // cookie_domain: location.hostname,        // default: current domain
+  // cookie_path: '/',                        // default: root
+  // cookie_same_site: 'Lax',
+  // use_rfc_cookie: false,                   // default: false
+  // revision: 0,                             // default: 0
 
-    gui_options: {
-        consent_modal: {
-            layout: 'cloud',                    // box,cloud,bar
-            position: 'bottom center',          // bottom,middle,top + left,right,center
-            transition: 'slide'                 // zoom,slide
-        },
-        settings_modal: {
-            layout: 'bar',                      // box,bar
-            position: 'left',                   // right,left (available only if bar layout selected)
-            transition: 'slide'                 // zoom,slide
-        }
+  gui_options: {
+    consent_modal: {
+      layout: "cloud", // box,cloud,bar
+      position: "bottom center", // bottom,middle,top + left,right,center
+      transition: "slide", // zoom,slide
     },
-
-    onFirstAction: function(){
-        console.log('onFirstAction fired');
+    settings_modal: {
+      layout: "bar", // box,bar
+      position: "left", // right,left (available only if bar layout selected)
+      transition: "slide", // zoom,slide
     },
+  },
 
-    onAccept: function(){
-        console.log('onAccept fired!')
+  onFirstAction: function () {
+    console.log("onFirstAction fired");
+  },
 
-        // If analytics category is disabled => load all iframes automatically
-        if(cc.allowedCategory('analytics')){
-            console.log('iframemanager: loading all iframes');
-            manager.acceptService('all');
-        }
-    },
+  onAccept: function () {
+    console.log("onAccept fired!");
 
-    onChange: function (cookie, changed_preferences) {
-        console.log('onChange fired!');
-
-        // If analytics category is disabled => ask for permission to load iframes
-        if(!cc.allowedCategory('analytics')){
-            console.log('iframemanager: disabling all iframes');
-            manager.rejectService('all');
-        }else{
-            console.log('iframemanager: loading all iframes');
-            manager.acceptService('all');
-        }
-    },
-
-    languages: {
-        'en': {
-            consent_modal: {
-                title: 'Hello traveller, it\'s cookie time!',
-                description: 'Our website uses essential cookies to ensure its proper operation and tracking cookies to understand how you interact with it. The latter will be set only after consent. <a href="#privacy-policy" class="cc-link">Privacy policy</a>',
-                primary_btn: {
-                    text: 'Accept all',
-                    role: 'accept_all'      //'accept_selected' or 'accept_all'
-                },
-                secondary_btn: {
-                    text: 'Preferences',
-                    role: 'settings'       //'settings' or 'accept_necessary'
-                },
-                revision_message: '<br><br> Dear user, terms and conditions have changed since the last time you visisted!'
-            },
-            settings_modal: {
-                title: 'Cookie settings',
-                save_settings_btn: 'Save current selection',
-                accept_all_btn: 'Accept all',
-                reject_all_btn: 'Reject all',
-                close_btn_label: 'Close',
-                cookie_table_headers: [
-                    {col1: 'Name'},
-                    {col2: 'Domain'},
-                    {col3: 'Expiration'}
-                ],
-                blocks: [
-                    {
-                        title: 'Cookie usage',
-                        description: LOREM_IPSUM + ' <a href="#" class="cc-link">Privacy Policy</a>.'
-                    }, {
-                        title: 'Strictly necessary cookies',
-                        description: LOREM_IPSUM + LOREM_IPSUM + "<br><br>" + LOREM_IPSUM + LOREM_IPSUM,
-                        toggle: {
-                            value: 'necessary',
-                            enabled: true,
-                            readonly: true  //cookie categories with readonly=true are all treated as "necessary cookies"
-                        }
-                    }, {
-                        title: 'Analytics & Performance cookies',
-                        description: LOREM_IPSUM,
-                        toggle: {
-                            value: 'analytics',
-                            enabled: false,
-                            readonly: false
-                        },
-                        cookie_table: [
-                            {
-                                col1: '^_ga',
-                                col2: 'yourdomain.com',
-                                col3: 'description ...',
-                                is_regex: true
-                            },
-                            {
-                                col1: '_gid',
-                                col2: 'yourdomain.com',
-                                col3: 'description ...',
-                            },
-                            {
-                                col1: 'cc_youtube',
-                                col2: 'yourdomain.com',
-                                col3: 'Cookie set by iframemanager'
-                            }
-                        ]
-                    }, {
-                        title: 'More information',
-                        description: LOREM_IPSUM + ' <a class="cc-link" href="https://orestbida.com/contact/">Contact me</a>.',
-                    }
-                ]
-            }
-        }
+    // If analytics category is disabled => load all iframes automatically
+    if (cc.allowedCategory("analytics")) {
+      console.log("iframemanager: loading all iframes");
+      manager.acceptService("all");
     }
+  },
+
+  onChange: function (cookie, changed_preferences) {
+    console.log("onChange fired!");
+
+    // If analytics category is disabled => ask for permission to load iframes
+    if (!cc.allowedCategory("analytics")) {
+      console.log("iframemanager: disabling all iframes");
+      manager.rejectService("all");
+    } else {
+      console.log("iframemanager: loading all iframes");
+      manager.acceptService("all");
+    }
+  },
+
+  languages: {
+    en: {
+      consent_modal: {
+        title: "Hello traveller, it's cookie time!",
+        description:
+          'Our website uses essential cookies to ensure its proper operation and tracking cookies to understand how you interact with it. The latter will be set only after consent. <a href="#privacy-policy" class="cc-link">Privacy policy</a>',
+        primary_btn: {
+          text: "Accept all",
+          role: "accept_all", //'accept_selected' or 'accept_all'
+        },
+        secondary_btn: {
+          text: "Preferences",
+          role: "settings", //'settings' or 'accept_necessary'
+        },
+        revision_message:
+          "<br><br> Dear user, terms and conditions have changed since the last time you visisted!",
+      },
+      settings_modal: {
+        title: "Cookie settings",
+        save_settings_btn: "Save current selection",
+        accept_all_btn: "Accept all",
+        reject_all_btn: "Reject all",
+        close_btn_label: "Close",
+        cookie_table_headers: [
+          { col1: "Name" },
+          { col2: "Domain" },
+          { col3: "Expiration" },
+        ],
+        blocks: [
+          {
+            title: "Cookie usage",
+            description:
+              LOREM_IPSUM + ' <a href="#" class="cc-link">Privacy Policy</a>.',
+          },
+          {
+            title: "Strictly necessary cookies",
+            description:
+              LOREM_IPSUM +
+              LOREM_IPSUM +
+              "<br><br>" +
+              LOREM_IPSUM +
+              LOREM_IPSUM,
+            toggle: {
+              value: "necessary",
+              enabled: true,
+              readonly: true, //cookie categories with readonly=true are all treated as "necessary cookies"
+            },
+          },
+          {
+            title: "Analytics & Performance cookies",
+            description: LOREM_IPSUM,
+            toggle: {
+              value: "analytics",
+              enabled: false,
+              readonly: false,
+            },
+            cookie_table: [
+              {
+                col1: "^_ga",
+                col2: "yourdomain.com",
+                col3: "description ...",
+                is_regex: true,
+              },
+              {
+                col1: "_gid",
+                col2: "yourdomain.com",
+                col3: "description ...",
+              },
+              {
+                col1: "cc_youtube",
+                col2: "yourdomain.com",
+                col3: "Cookie set by iframemanager",
+              },
+            ],
+          },
+          {
+            title: "More information",
+            description:
+              LOREM_IPSUM +
+              ' <a class="cc-link" href="https://orestbida.com/contact/">Contact me</a>.',
+          },
+        ],
+      },
+    },
+  },
 });

--- a/demo/demo_iframemanager/cookieconsent-init.js
+++ b/demo/demo_iframemanager/cookieconsent-init.js
@@ -1,5 +1,4 @@
-var LOREM_IPSUM =
-    "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
+var LOREM_IPSUM = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.';
 
 // obtain iframemanager object
 var manager = iframemanager();
@@ -9,21 +8,21 @@ var cc = initCookieConsent();
 
 // Configure with youtube embed
 manager.run({
-    currLang: "en",
+    currLang: 'en',
     services: {
         youtube: {
-            embedUrl: "https://www.youtube-nocookie.com/embed/{data-id}",
-            thumbnailUrl: "https://i3.ytimg.com/vi/{data-id}/hqdefault.jpg",
+            embedUrl: 'https://www.youtube-nocookie.com/embed/{data-id}',
+            thumbnailUrl: 'https://i3.ytimg.com/vi/{data-id}/hqdefault.jpg',
             iframe: {
-                allow: "accelerometer; encrypted-media; gyroscope; picture-in-picture; fullscreen;",
+                allow: 'accelerometer; encrypted-media; gyroscope; picture-in-picture; fullscreen;',
             },
             cookie: {
-                name: "cc_youtube",
+                name: 'cc_youtube',
             },
             languages: {
                 en: {
                     notice: 'This content is hosted by a third party. By showing the external content you accept the <a rel="noreferrer" href="https://www.youtube.com/t/terms" title="Terms and conditions" target="_blank">terms and conditions</a> of youtube.com.',
-                    loadBtn: "Load video",
+                    loadBtn: 'Load video',
                     loadAllBtn: "Don't ask again",
                 },
             },
@@ -33,9 +32,9 @@ manager.run({
 
 // run plugin with config object
 cc.run({
-    current_lang: "en",
+    current_lang: 'en',
     autoclear_cookies: true, // default: false
-    cookie_name: "cc_cookie_demo2", // default: 'cc_cookie'
+    cookie_name: 'cc_cookie_demo2', // default: 'cc_cookie'
     cookie_expiration: 365, // default: 182
     // page_scripts: false,                         // default: false
     force_consent: true, // default: false
@@ -53,41 +52,41 @@ cc.run({
 
     gui_options: {
         consent_modal: {
-            layout: "cloud", // box,cloud,bar
-            position: "bottom center", // bottom,middle,top + left,right,center
-            transition: "slide", // zoom,slide
+            layout: 'cloud', // box,cloud,bar
+            position: 'bottom center', // bottom,middle,top + left,right,center
+            transition: 'slide', // zoom,slide
         },
         settings_modal: {
-            layout: "bar", // box,bar
-            position: "left", // right,left (available only if bar layout selected)
-            transition: "slide", // zoom,slide
+            layout: 'bar', // box,bar
+            position: 'left', // right,left (available only if bar layout selected)
+            transition: 'slide', // zoom,slide
         },
     },
 
     onFirstAction: function () {
-        console.log("onFirstAction fired");
+        console.log('onFirstAction fired');
     },
 
     onAccept: function () {
-        console.log("onAccept fired!");
+        console.log('onAccept fired!');
 
         // If analytics category is disabled => load all iframes automatically
-        if (cc.allowedCategory("analytics")) {
-            console.log("iframemanager: loading all iframes");
-            manager.acceptService("all");
+        if (cc.allowedCategory('analytics')) {
+            console.log('iframemanager: loading all iframes');
+            manager.acceptService('all');
         }
     },
 
     onChange: function (cookie, changed_preferences) {
-        console.log("onChange fired!");
+        console.log('onChange fired!');
 
         // If analytics category is disabled => ask for permission to load iframes
-        if (!cc.allowedCategory("analytics")) {
-            console.log("iframemanager: disabling all iframes");
-            manager.rejectService("all");
+        if (!cc.allowedCategory('analytics')) {
+            console.log('iframemanager: disabling all iframes');
+            manager.rejectService('all');
         } else {
-            console.log("iframemanager: loading all iframes");
-            manager.acceptService("all");
+            console.log('iframemanager: loading all iframes');
+            manager.acceptService('all');
         }
     },
 
@@ -95,83 +94,68 @@ cc.run({
         en: {
             consent_modal: {
                 title: "Hello traveller, it's cookie time!",
-                description:
-                    'Our website uses essential cookies to ensure its proper operation and tracking cookies to understand how you interact with it. The latter will be set only after consent. <a href="#privacy-policy" class="cc-link">Privacy policy</a>',
+                description: 'Our website uses essential cookies to ensure its proper operation and tracking cookies to understand how you interact with it. The latter will be set only after consent. <a href="#privacy-policy" class="cc-link">Privacy policy</a>',
                 primary_btn: {
-                    text: "Accept all",
-                    role: "accept_all", //'accept_selected' or 'accept_all'
+                    text: 'Accept all',
+                    role: 'accept_all', //'accept_selected' or 'accept_all'
                 },
                 secondary_btn: {
-                    text: "Preferences",
-                    role: "settings", //'settings' or 'accept_necessary'
+                    text: 'Preferences',
+                    role: 'settings', //'settings' or 'accept_necessary'
                 },
-                revision_message:
-                    "<br><br> Dear user, terms and conditions have changed since the last time you visisted!",
+                revision_message: '<br><br> Dear user, terms and conditions have changed since the last time you visisted!',
             },
             settings_modal: {
-                title: "Cookie settings",
-                save_settings_btn: "Save current selection",
-                accept_all_btn: "Accept all",
-                reject_all_btn: "Reject all",
-                close_btn_label: "Close",
-                cookie_table_headers: [
-                    { col1: "Name" },
-                    { col2: "Domain" },
-                    { col3: "Expiration" },
-                ],
+                title: 'Cookie settings',
+                save_settings_btn: 'Save current selection',
+                accept_all_btn: 'Accept all',
+                reject_all_btn: 'Reject all',
+                close_btn_label: 'Close',
+                cookie_table_headers: [{ col1: 'Name' }, { col2: 'Domain' }, { col3: 'Expiration' }],
                 blocks: [
                     {
-                        title: "Cookie usage",
-                        description:
-                            LOREM_IPSUM +
-                            ' <a href="#" class="cc-link">Privacy Policy</a>.',
+                        title: 'Cookie usage',
+                        description: LOREM_IPSUM + ' <a href="#" class="cc-link">Privacy Policy</a>.',
                     },
                     {
-                        title: "Strictly necessary cookies",
-                        description:
-                            LOREM_IPSUM +
-                            LOREM_IPSUM +
-                            "<br><br>" +
-                            LOREM_IPSUM +
-                            LOREM_IPSUM,
+                        title: 'Strictly necessary cookies',
+                        description: LOREM_IPSUM + LOREM_IPSUM + '<br><br>' + LOREM_IPSUM + LOREM_IPSUM,
                         toggle: {
-                            value: "necessary",
+                            value: 'necessary',
                             enabled: true,
                             readonly: true, //cookie categories with readonly=true are all treated as "necessary cookies"
                         },
                     },
                     {
-                        title: "Analytics & Performance cookies",
+                        title: 'Analytics & Performance cookies',
                         description: LOREM_IPSUM,
                         toggle: {
-                            value: "analytics",
+                            value: 'analytics',
                             enabled: false,
                             readonly: false,
                         },
                         cookie_table: [
                             {
-                                col1: "^_ga",
-                                col2: "yourdomain.com",
-                                col3: "description ...",
+                                col1: '^_ga',
+                                col2: 'yourdomain.com',
+                                col3: 'description ...',
                                 is_regex: true,
                             },
                             {
-                                col1: "_gid",
-                                col2: "yourdomain.com",
-                                col3: "description ...",
+                                col1: '_gid',
+                                col2: 'yourdomain.com',
+                                col3: 'description ...',
                             },
                             {
-                                col1: "cc_youtube",
-                                col2: "yourdomain.com",
-                                col3: "Cookie set by iframemanager",
+                                col1: 'cc_youtube',
+                                col2: 'yourdomain.com',
+                                col3: 'Cookie set by iframemanager',
                             },
                         ],
                     },
                     {
-                        title: "More information",
-                        description:
-                            LOREM_IPSUM +
-                            ' <a class="cc-link" href="https://orestbida.com/contact/">Contact me</a>.',
+                        title: 'More information',
+                        description: LOREM_IPSUM + ' <a class="cc-link" href="https://orestbida.com/contact/">Contact me</a>.',
                     },
                 ],
             },

--- a/demo/demo_iframemanager/index.html
+++ b/demo/demo_iframemanager/index.html
@@ -1,41 +1,70 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
+  <head>
+    <meta charset="UTF-8" />
     <title>CookieConsent demo</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="../assets/demo.css">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="../assets/demo.css" />
     <script src="../assets/demo.js" defer></script>
 
     <!-- Load plugin css -->
     <!-- <link rel="stylesheet" href="../../dist/cookieconsent.css"> -->
     <!-- Optimized css loading -->
-    <link rel="stylesheet" href="../../dist/cookieconsent.css" media="print" onload="this.media='all'">
+    <link
+      rel="stylesheet"
+      href="../../src/cookieconsent.css"
+      media="print"
+      onload="this.media='all'"
+    />
 
     <!-- Load iframemanager css -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orestbida/iframemanager@v1.0/dist/iframemanager.css" media="print" onload="this.media='all'">
-</head>
-<body>
-
-    <h1><a href="https://orestbida.com/demo-projects/cookieconsent/" target="_blank" class="demo-title">CookieConsent 🡥</a></h1>
-    <h2>Example configuration with <a href="https://github.com/orestbida/iframemanager" target="_blank">iframemanager 🡥</a> (iframe blocking)</h2>
-    <br>
-    <p>Check your <a href="https://developer.chrome.com/docs/devtools/shortcuts/#open" target="_blank">browser's console 🡥</a> to see what's happening!</p>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/gh/orestbida/iframemanager@v1.0/dist/iframemanager.css"
+      media="print"
+      onload="this.media='all'"
+    />
+  </head>
+  <body>
+    <h1>
+      <a
+        href="https://orestbida.com/demo-projects/cookieconsent/"
+        target="_blank"
+        class="demo-title"
+        >CookieConsent 🡥</a
+      >
+    </h1>
+    <h2>
+      Example configuration with
+      <a href="https://github.com/orestbida/iframemanager" target="_blank"
+        >iframemanager 🡥</a
+      >
+      (iframe blocking)
+    </h2>
+    <br />
+    <p>
+      Check your
+      <a
+        href="https://developer.chrome.com/docs/devtools/shortcuts/#open"
+        target="_blank"
+        >browser's console 🡥</a
+      >
+      to see what's happening!
+    </p>
     <button type="button" data-cc="c-settings">Cookie settings</button>
-    <br>
-    <br>
+    <br />
+    <br />
 
     <!-- youtube iframe -->
-    <div
-        data-service="youtube"
-        data-id="Zya4bDgVU9k"
-        data-autoscale>
-    </div>
+    <div data-service="youtube" data-id="Zya4bDgVU9k" data-autoscale></div>
 
-    <br>
+    <br />
 
-    <script defer src="https://cdn.jsdelivr.net/gh/orestbida/iframemanager@v1.0/dist/iframemanager.js"></script>
+    <script
+      defer
+      src="https://cdn.jsdelivr.net/gh/orestbida/iframemanager@v1.0/dist/iframemanager.js"
+    ></script>
     <script defer src="../../src/cookieconsent.js"></script>
     <script defer src="cookieconsent-init.js"></script>
-</body>
+  </body>
 </html>

--- a/src/cookieconsent.css
+++ b/src/cookieconsent.css
@@ -1,130 +1,131 @@
 /** Light color-scheme **/
-:root{
-    --cc-bg: #fff;
-    --cc-text: #2d4156;
-    --cc-btn-primary-bg: #2d4156;
-    --cc-btn-primary-text: var(--cc-bg);
-    --cc-btn-primary-hover-bg: #1d2e38;
-    --cc-btn-secondary-bg: #eaeff2;
-    --cc-btn-secondary-text: var(--cc-text);
-    --cc-btn-secondary-hover-bg: #d8e0e6;
-    --cc-toggle-bg-off: #919ea6;
-    --cc-toggle-bg-on: var(--cc-btn-primary-bg);
-    --cc-toggle-bg-readonly: #d5dee2;
-    --cc-toggle-knob-bg: #fff;
-    --cc-toggle-knob-icon-color: #ecf2fa;
-    --cc-block-text: var(--cc-text);
-    --cc-cookie-category-block-bg: #f0f4f7;
-    --cc-cookie-category-block-bg-hover: #e9eff4;
-    --cc-section-border: #f1f3f5;
-    --cc-cookie-table-border: #e9edf2;
-    --cc-overlay-bg: rgba(4, 6, 8, .85);
-    --cc-webkit-scrollbar-bg: #cfd5db;
-    --cc-webkit-scrollbar-bg-hover: #9199a0;
+:root {
+  --cc-bg: #fff;
+  --cc-text: #2d4156;
+  --cc-btn-primary-bg: #2d4156;
+  --cc-btn-primary-text: var(--cc-bg);
+  --cc-btn-primary-hover-bg: #1d2e38;
+  --cc-btn-secondary-bg: #eaeff2;
+  --cc-btn-secondary-text: var(--cc-text);
+  --cc-btn-secondary-hover-bg: #d8e0e6;
+  --cc-toggle-bg-off: #919ea6;
+  --cc-toggle-bg-on: var(--cc-btn-primary-bg);
+  --cc-toggle-bg-readonly: #d5dee2;
+  --cc-toggle-knob-bg: #fff;
+  --cc-toggle-knob-icon-color: #ecf2fa;
+  --cc-block-text: var(--cc-text);
+  --cc-cookie-category-block-bg: #f0f4f7;
+  --cc-cookie-category-block-bg-hover: #e9eff4;
+  --cc-section-border: #f1f3f5;
+  --cc-cookie-table-border: #e9edf2;
+  --cc-overlay-bg: rgba(4, 6, 8, 0.85);
+  --cc-webkit-scrollbar-bg: #cfd5db;
+  --cc-webkit-scrollbar-bg-hover: #9199a0;
 }
 
 /** Dark color-scheme **/
-.c_darkmode{
-    --cc-bg: #181b1d;
-    --cc-text: #d8e5ea;
-    --cc-btn-primary-bg: #a6c4dd;
-    --cc-btn-primary-text: #000;
-    --cc-btn-primary-hover-bg: #c2dff7;
-    --cc-btn-secondary-bg: #33383c;
-    --cc-btn-secondary-text: var(--cc-text);
-    --cc-btn-secondary-hover-bg: #3e454a;
-    --cc-toggle-bg-off: #667481;
-    --cc-toggle-bg-on: var(--cc-btn-primary-bg);
-    --cc-toggle-bg-readonly: #454c54;
-    --cc-toggle-knob-bg: var(--cc-cookie-category-block-bg);
-    --cc-toggle-knob-icon-color: var(--cc-bg);
-    --cc-block-text: #b3bfc5;
-    --cc-cookie-category-block-bg: #23272a;
-    --cc-cookie-category-block-bg-hover: #2b3035;
-    --cc-section-border: #292d31;
-    --cc-cookie-table-border: #2b3035;
-    --cc-webkit-scrollbar-bg: #667481;
-    --cc-webkit-scrollbar-bg-hover: #9199a0;
+.c_darkmode {
+  --cc-bg: #181b1d;
+  --cc-text: #d8e5ea;
+  --cc-btn-primary-bg: #a6c4dd;
+  --cc-btn-primary-text: #000;
+  --cc-btn-primary-hover-bg: #c2dff7;
+  --cc-btn-secondary-bg: #33383c;
+  --cc-btn-secondary-text: var(--cc-text);
+  --cc-btn-secondary-hover-bg: #3e454a;
+  --cc-toggle-bg-off: #667481;
+  --cc-toggle-bg-on: var(--cc-btn-primary-bg);
+  --cc-toggle-bg-readonly: #454c54;
+  --cc-toggle-knob-bg: var(--cc-cookie-category-block-bg);
+  --cc-toggle-knob-icon-color: var(--cc-bg);
+  --cc-block-text: #b3bfc5;
+  --cc-cookie-category-block-bg: #23272a;
+  --cc-cookie-category-block-bg-hover: #2b3035;
+  --cc-section-border: #292d31;
+  --cc-cookie-table-border: #2b3035;
+  --cc-webkit-scrollbar-bg: #667481;
+  --cc-webkit-scrollbar-bg-hover: #9199a0;
 }
 
 .cc_div *,
 .cc_div *:hover,
 .cc_div :before,
-.cc_div :after{
-    -webkit-box-sizing: border-box;
-    box-sizing: border-box;
-    float: none;
-    font-style: inherit;
-    font-variant: normal;
-    font-weight: inherit;
-    font-family: inherit;
-	line-height: 1.2;
-    font-size: 1em;
-    transition: none;
-    animation: none;
-    margin: 0;
-    padding: 0;
-    text-transform: none;
-    letter-spacing: unset;
-    color: inherit;
-    background: none;
-    border: none;
-    border-radius: unset;
-    box-shadow: none;
-    text-decoration: none;
-    text-align: left;
-    visibility: unset;
-    height: auto;
-    vertical-align: baseline;
+.cc_div :after {
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  float: none;
+  font-style: inherit;
+  font-variant: normal;
+  font-weight: inherit;
+  font-family: inherit;
+  line-height: 1.2;
+  font-size: 1em;
+  transition: none;
+  animation: none;
+  margin: 0;
+  padding: 0;
+  text-transform: none;
+  letter-spacing: unset;
+  color: inherit;
+  background: none;
+  border: none;
+  border-radius: unset;
+  box-shadow: none;
+  text-decoration: none;
+  text-align: left;
+  visibility: unset;
+  height: auto;
+  vertical-align: baseline;
 }
 
 .cc_div {
-    font-size: 16px;
-    font-weight: 400;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    text-rendering: optimizeLegibility;
-    color: #2d4156;
-    color: var(--cc-text);
+  font-size: 16px;
+  font-weight: 400;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica,
+    Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+  color: #2d4156;
+  color: var(--cc-text);
 }
 
 .cc_div .c-bn,
 .cc_div .b-tl,
 #s-ttl,
 #c-ttl,
-#s-bl td:before{
-    font-weight: 600;
+#s-bl td:before {
+  font-weight: 600;
 }
 
 #cm,
 #s-inr,
 .cc_div .c-bl,
 .cc_div .b-tl,
-#s-bl .act .b-acc{
-    border-radius: .35em;
+#s-bl .act .b-acc {
+  border-radius: 0.35em;
 }
 
-#s-bl .act .b-acc{
-    border-top-left-radius: 0;
-    border-top-right-radius: 0;
+#s-bl .act .b-acc {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
 }
 
 .cc_div input,
 .cc_div button,
-.cc_div a{
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    appearance: none;
+.cc_div a {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
 }
 
-.cc_div a{
-    border-bottom: 1px solid;
+.cc_div a {
+  border-bottom: 1px solid;
 }
 
-.cc_div a:hover{
-    text-decoration: none;
-    border-color: transparent;
+.cc_div a:hover {
+  text-decoration: none;
+  border-color: transparent;
 }
 
 /* Make elements "animatable" */
@@ -132,52 +133,52 @@
 .c--anim #s-cnt,
 .c--anim #s-inr,
 #cs-ov,
-#cm-ov{
-    transition: visibility .25s linear, opacity .25s ease, transform .25s ease!important;
+#cm-ov {
+  transition: visibility 0.25s linear, opacity 0.25s ease, transform 0.25s ease !important;
 }
 
-.c--anim .c-bn{
-    transition: background-color .25s ease!important;
+.c--anim .c-bn {
+  transition: background-color 0.25s ease !important;
 }
 
 /* start transitions */
 .c--anim #cm.bar.slide,
-.c--anim .bar.slide #s-inr{
-    transition: visibility .4s ease, opacity .4s ease, transform .4s ease!important;
+.c--anim .bar.slide #s-inr {
+  transition: visibility 0.4s ease, opacity 0.4s ease, transform 0.4s ease !important;
 }
 
 .c--anim #cm.bar.slide + #cm-ov,
-.c--anim .bar.slide + #cs-ov{
-    transition: visibility .4s ease, opacity .4s ease, transform .4s ease!important;
+.c--anim .bar.slide + #cs-ov {
+  transition: visibility 0.4s ease, opacity 0.4s ease, transform 0.4s ease !important;
 }
 
 #cm.bar.slide,
-.cc_div .bar.slide #s-inr{
-    transform: translateX(100%);
-    opacity: 1;
+.cc_div .bar.slide #s-inr {
+  transform: translateX(100%);
+  opacity: 1;
 }
 
 #cm.bar.top.slide,
-.cc_div .bar.left.slide #s-inr{
-    transform: translateX(-100%);
-    opacity: 1;
+.cc_div .bar.left.slide #s-inr {
+  transform: translateX(-100%);
+  opacity: 1;
 }
 
 #cm.slide,
-.cc_div .slide #s-inr{
-    transform: translateY(1.6em);
+.cc_div .slide #s-inr {
+  transform: translateY(1.6em);
 }
 
-#cm.top.slide{
-    transform: translateY(-1.6em);
+#cm.top.slide {
+  transform: translateY(-1.6em);
 }
 
-#cm.bar.slide{
-    transform: translateY(100%);
+#cm.bar.slide {
+  transform: translateY(100%);
 }
 
-#cm.bar.top.slide{
-    transform: translateY(-100%);
+#cm.bar.top.slide {
+  transform: translateY(-100%);
 }
 /* end transitions */
 
@@ -186,100 +187,114 @@
 .show--consent .c--anim #cm,
 .show--consent .c--anim #cm.bar,
 .show--settings .c--anim #s-inr,
-.show--settings .c--anim .bar.slide #s-inr{
-    opacity: 1;
-    transform: scale(1);
-    visibility: visible!important;
+.show--settings .c--anim .bar.slide #s-inr {
+  opacity: 1;
+  transform: scale(1);
+  visibility: visible !important;
 }
 
 .show--consent .c--anim #cm.box.middle,
-.show--consent .c--anim #cm.cloud.middle{
-    transform: scale(1) translateY(-50%);
+.show--consent .c--anim #cm.cloud.middle {
+  transform: scale(1) translateY(-50%);
 }
 
-.show--settings .c--anim #s-cnt{
-    visibility: visible!important;
+.show--settings .c--anim #s-cnt {
+  visibility: visible !important;
 }
 
 /* Show overlays */
 .force--consent.show--consent .c--anim #cm-ov,
-.show--settings .c--anim #cs-ov{
-    visibility: visible!important;
-    opacity: 1!important;
+.show--settings .c--anim #cs-ov {
+  visibility: visible !important;
+  opacity: 1 !important;
 }
 
-#cm{
-    font-family: inherit;
-    padding: 1.1em 1.8em 1.4em 1.8em;
-    position: fixed;
-    z-index: 1;
-    background: #fff;
-    background: var(--cc-bg);
-    max-width: 24.2em;
-    width: 100%;
-    bottom: 1.250em;
-    right: 1.250em;
-    box-shadow: 0 0.625em 1.875em #000000;
-    box-shadow: 0 0.625em 1.875em rgba(2, 2, 3, 0.28);
-    opacity: 0;
-    visibility: hidden;
-    transform: scale(.95);
-    line-height: initial;
+#cm {
+  font-family: inherit;
+  padding: 1.1em 1.8em 1.4em 1.8em;
+  position: fixed;
+  z-index: 1;
+  background: #fff;
+  background: var(--cc-bg);
+  max-width: 24.2em;
+  width: 100%;
+  bottom: 1.25em;
+  right: 1.25em;
+  box-shadow: 0 0.625em 1.875em #000000;
+  box-shadow: 0 0.625em 1.875em rgba(2, 2, 3, 0.28);
+  opacity: 0;
+  visibility: hidden;
+  transform: scale(0.95);
+  line-height: initial;
 }
 
 /** fix https://github.com/orestbida/cookieconsent/issues/94 **/
 #cc_div #cm {
-    display: block!important;
+  display: block !important;
 }
 
-#c-ttl{
-    margin-bottom: .7em;
-    font-size: 1.05em;
+#c-ttl {
+  margin-bottom: 0.7em;
+  font-size: 1.05em;
 }
 
-.cloud #c-ttl{
-    margin-top: -.15em;
+.cloud #c-ttl {
+  margin-top: -0.15em;
 }
 
-#c-txt{
-    font-size: 0.9em;
-    line-height: 1.5em;
+#c-txt {
+  font-size: 0.9em;
+  line-height: 1.5em;
 }
 
-.cc_div #c-bns{
-    display: flex;
-    justify-content: space-between;
-    margin-top: 1.4em;
+.cc_div #c-bns {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 1.4em;
 }
 
-.cc_div .c-bn{
-    color: #40505a;
-    color: var(--cc-btn-secondary-text);
-    background: #e5ebef;
-    background: var(--cc-btn-secondary-bg);
-    padding: 1em 1.7em;
-    display: inline-block;
-    cursor: pointer;
-    font-size: 0.82em;
-    -moz-user-select: none;
-    -khtml-user-select: none;
-    -webkit-user-select: none;
-    -o-user-select: none;
-    user-select: none;
-    text-align: center;
-    border-radius: 4px;
-    flex: 1;
+.cc_div .c-bn {
+  color: #40505a;
+  color: var(--cc-btn-secondary-text);
+  background: #e5ebef;
+  background: var(--cc-btn-secondary-bg);
+  padding: 1em 1.7em;
+  display: inline-block;
+  cursor: pointer;
+  font-size: 0.82em;
+  -moz-user-select: none;
+  -khtml-user-select: none;
+  -webkit-user-select: none;
+  -o-user-select: none;
+  user-select: none;
+  text-align: center;
+  border-radius: 4px;
+  flex: 1;
+}
+
+#c-link {
+  display: flex;
+  justify-content: center;
+  padding-top: 10px;
+}
+
+#c-link .cc-link {
+  font-size: 0.9em;
+}
+
+#c-link .cc-link + .cc-link {
+  margin-left: 15px;
 }
 
 #c-bns button + button,
 #s-cnt button + button,
-#s-c-bn{
-    float: right;
-    margin-left: 1em;
+#s-c-bn {
+  float: right;
+  margin-left: 1em;
 }
 
-#s-cnt #s-rall-bn{
-    float: none;
+#s-cnt #s-rall-bn {
+  float: none;
 }
 
 #cm .c_link:hover,
@@ -287,259 +302,259 @@
 #s-cnt button + button:hover,
 #s-cnt button + button:active,
 #s-c-bn:active,
-#s-c-bn:hover{
-    background: #d8e0e6;
-    background: var(--cc-btn-secondary-hover-bg);
+#s-c-bn:hover {
+  background: #d8e0e6;
+  background: var(--cc-btn-secondary-hover-bg);
 }
 
 /**
 CookieConsent settings modal
 **/
-#s-cnt{
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    z-index: 101;
-    display: table;
-    height: 100%;
-    visibility: hidden;
+#s-cnt {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  z-index: 101;
+  display: table;
+  height: 100%;
+  visibility: hidden;
 }
 
-#s-bl{
-    outline: none;
+#s-bl {
+  outline: none;
 }
 
-#s-bl .title{
-    margin-top: 1.4em;
+#s-bl .title {
+  margin-top: 1.4em;
 }
 
-#s-bl .title:first-child{
-    margin-top: 0;
+#s-bl .title:first-child {
+  margin-top: 0;
 }
 
-#s-bl .b-bn{
-    margin-top: 0;
+#s-bl .b-bn {
+  margin-top: 0;
 }
 
-#s-bl .b-acc .p{
-    margin-top: 0;
-    padding: 1em;
+#s-bl .b-acc .p {
+  margin-top: 0;
+  padding: 1em;
 }
 
-#s-cnt .b-bn .b-tl{
-    display: block;
-    font-family: inherit;
-    font-size: .95em;
-    width: 100%;
-    position: relative;
-    padding: 1.3em 6.4em 1.3em 2.7em;
-    background: none;
-    transition: background-color .25s ease;
+#s-cnt .b-bn .b-tl {
+  display: block;
+  font-family: inherit;
+  font-size: 0.95em;
+  width: 100%;
+  position: relative;
+  padding: 1.3em 6.4em 1.3em 2.7em;
+  background: none;
+  transition: background-color 0.25s ease;
 }
 
-#s-cnt .b-bn .b-tl.exp{
-    cursor: pointer;
+#s-cnt .b-bn .b-tl.exp {
+  cursor: pointer;
 }
 
-#s-cnt .act .b-bn .b-tl{
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+#s-cnt .act .b-bn .b-tl {
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
 }
 
 #s-cnt .b-bn .b-tl:active,
-#s-cnt .b-bn .b-tl:hover{
-    background: #e9eff4;
-    background: var(--cc-cookie-category-block-bg-hover);
+#s-cnt .b-bn .b-tl:hover {
+  background: #e9eff4;
+  background: var(--cc-cookie-category-block-bg-hover);
 }
 
-#s-bl .b-bn{
-    position: relative;
+#s-bl .b-bn {
+  position: relative;
 }
 
-#s-bl .c-bl{
-    padding: 1em;
-    margin-bottom: .5em;
-    border: 1px solid #f1f3f5;
-    border-color: var(--cc-section-border);
-    transition: background-color .25s ease;
+#s-bl .c-bl {
+  padding: 1em;
+  margin-bottom: 0.5em;
+  border: 1px solid #f1f3f5;
+  border-color: var(--cc-section-border);
+  transition: background-color 0.25s ease;
 }
 
-#s-bl .c-bl:hover{
-    background: #f0f4f7;
-    background: var(--cc-cookie-category-block-bg);
+#s-bl .c-bl:hover {
+  background: #f0f4f7;
+  background: var(--cc-cookie-category-block-bg);
 }
 
-#s-bl .c-bl:last-child{
-    margin-bottom: .5em;
+#s-bl .c-bl:last-child {
+  margin-bottom: 0.5em;
 }
 
-#s-bl .c-bl:first-child{
-    transition: none;
-    padding: 0;
-    margin-top: 0;
-    border:none;
-    margin-bottom: 2em;
+#s-bl .c-bl:first-child {
+  transition: none;
+  padding: 0;
+  margin-top: 0;
+  border: none;
+  margin-bottom: 2em;
 }
 
-#s-bl .c-bl:not(.b-ex):first-child:hover{
-    background: transparent;
-    background: unset;
+#s-bl .c-bl:not(.b-ex):first-child:hover {
+  background: transparent;
+  background: unset;
 }
 
-#s-bl .c-bl.b-ex{
-    padding: 0;
-    border: none;
-    background: #f0f4f7;
-    background: var(--cc-cookie-category-block-bg);
-    transition: none;
+#s-bl .c-bl.b-ex {
+  padding: 0;
+  border: none;
+  background: #f0f4f7;
+  background: var(--cc-cookie-category-block-bg);
+  transition: none;
 }
 
-#s-bl .c-bl.b-ex + .c-bl{
-    margin-top: 2em;
+#s-bl .c-bl.b-ex + .c-bl {
+  margin-top: 2em;
 }
 
-#s-bl .c-bl.b-ex + .c-bl.b-ex{
-    margin-top: 0;
+#s-bl .c-bl.b-ex + .c-bl.b-ex {
+  margin-top: 0;
 }
 
-#s-bl .c-bl.b-ex:first-child{
-    margin-bottom: 1em;
+#s-bl .c-bl.b-ex:first-child {
+  margin-bottom: 1em;
 }
 
-#s-bl .c-bl.b-ex:first-child{
-    margin-bottom: .5em;
+#s-bl .c-bl.b-ex:first-child {
+  margin-bottom: 0.5em;
 }
 
-#s-bl .b-acc{
-    max-height: 0;
-    overflow: hidden;
-    padding-top: 0;
-    margin-bottom: 0;
-    display: none;
+#s-bl .b-acc {
+  max-height: 0;
+  overflow: hidden;
+  padding-top: 0;
+  margin-bottom: 0;
+  display: none;
 }
 
-#s-bl .act .b-acc{
-    max-height: 100%;
-    display: block;
-    overflow: hidden;
+#s-bl .act .b-acc {
+  max-height: 100%;
+  display: block;
+  overflow: hidden;
 }
 
-#s-cnt .p{
-    font-size: 0.9em;
-    line-height: 1.5em;
-    margin-top: .85em;
-    color: #2d4156;
-    color: var(--cc-block-text);
+#s-cnt .p {
+  font-size: 0.9em;
+  line-height: 1.5em;
+  margin-top: 0.85em;
+  color: #2d4156;
+  color: var(--cc-block-text);
 }
 
-.cc_div .b-tg .c-tgl:disabled{
-    cursor: not-allowed;
+.cc_div .b-tg .c-tgl:disabled {
+  cursor: not-allowed;
 }
 
-#c-vln{
-    display: table-cell;
-    vertical-align: middle;
-    position: relative;
+#c-vln {
+  display: table-cell;
+  vertical-align: middle;
+  position: relative;
 }
 
-#cs{
-    padding: 0 1.7em;
-    width: 100%;
-    position: fixed;
-    left: 0;
-    right: 0;
-    top: 0;
-    bottom: 0;
-    height: 100%;
+#cs {
+  padding: 0 1.7em;
+  width: 100%;
+  position: fixed;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  height: 100%;
 }
 
-#s-inr{
-    height: 100%;
-    position: relative;
-    max-width: 45em;
-    margin: 0 auto;
-    transform: scale(.96);
-    opacity: 0;
-    padding-top: 4.75em;
-    padding-bottom: 4.75em;
-    position: relative;
-    height: 100%;
-    overflow: hidden;
-    visibility: hidden;
-    box-shadow: rgba(3, 6, 9, .26) 0px 13px 27px -5px;
+#s-inr {
+  height: 100%;
+  position: relative;
+  max-width: 45em;
+  margin: 0 auto;
+  transform: scale(0.96);
+  opacity: 0;
+  padding-top: 4.75em;
+  padding-bottom: 4.75em;
+  position: relative;
+  height: 100%;
+  overflow: hidden;
+  visibility: hidden;
+  box-shadow: rgba(3, 6, 9, 0.26) 0px 13px 27px -5px;
 }
 
 #s-inr,
 #s-hdr,
-#s-bns{
-    background: #fff;
-    background: var(--cc-bg);
+#s-bns {
+  background: #fff;
+  background: var(--cc-bg);
 }
 
-#s-bl{
-	overflow-y: auto;
-    overflow-y: overlay;
-    overflow-x: hidden;
-    height: 100%;
-    padding: 1.3em 2.1em;
-    display: block;
-    width: 100%;
+#s-bl {
+  overflow-y: auto;
+  overflow-y: overlay;
+  overflow-x: hidden;
+  height: 100%;
+  padding: 1.3em 2.1em;
+  display: block;
+  width: 100%;
 }
 
-#s-bns{
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    padding: 1em 2.1em;
-    border-top: 1px solid #f1f3f5;
-    border-color: var(--cc-section-border);
-    height: 4.75em;
+#s-bns {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 1em 2.1em;
+  border-top: 1px solid #f1f3f5;
+  border-color: var(--cc-section-border);
+  height: 4.75em;
 }
 
-.cc_div .cc-link{
-    color: #253b48;
-    color: var(--cc-btn-primary-bg);
-    border-bottom: 1px solid #253b48;
-    border-color: var(--cc-btn-primary-bg);
-    display: inline;
-    padding-bottom: 0;
-    text-decoration: none;
-    cursor: pointer;
-    font-weight: 600;
+.cc_div .cc-link {
+  color: #253b48;
+  color: var(--cc-btn-primary-bg);
+  border-bottom: 1px solid #253b48;
+  border-color: var(--cc-btn-primary-bg);
+  display: inline;
+  padding-bottom: 0;
+  text-decoration: none;
+  cursor: pointer;
+  font-weight: 600;
 }
 
 .cc_div .cc-link:hover,
-.cc_div .cc-link:active{
-    border-color: transparent;
+.cc_div .cc-link:active {
+  border-color: transparent;
 }
 
 #c-bns button:first-child,
-#s-bns button:first-child{
-    color: #fff;
-    color: var(--cc-btn-primary-text);
-    background: #253b48;
-    background: var(--cc-btn-primary-bg);
+#s-bns button:first-child {
+  color: #fff;
+  color: var(--cc-btn-primary-text);
+  background: #253b48;
+  background: var(--cc-btn-primary-bg);
 }
 
-#c-bns.swap button:first-child{
-    color: #40505a;
-    color: var(--cc-btn-secondary-text);
-    background: #e5ebef;
-    background: var(--cc-btn-secondary-bg);
+#c-bns.swap button:first-child {
+  color: #40505a;
+  color: var(--cc-btn-secondary-text);
+  background: #e5ebef;
+  background: var(--cc-btn-secondary-bg);
 }
 
-#c-bns.swap button:last-child{
-    color: #fff;
-    color: var(--cc-btn-primary-text);
-    background: #253b48;
-    background: var(--cc-btn-primary-bg);
+#c-bns.swap button:last-child {
+  color: #fff;
+  color: var(--cc-btn-primary-text);
+  background: #253b48;
+  background: var(--cc-btn-primary-bg);
 }
 
-.cc_div .b-tg .c-tgl:checked ~ .c-tg{
-    background: #253b48;
-    background: var(--cc-toggle-bg-on);
+.cc_div .b-tg .c-tgl:checked ~ .c-tg {
+  background: #253b48;
+  background: var(--cc-toggle-bg-on);
 }
 
 #c-bns button:first-child:active,
@@ -547,555 +562,748 @@ CookieConsent settings modal
 #s-bns button:first-child:active,
 #s-bns button:first-child:hover,
 #c-bns.swap button:last-child:active,
-#c-bns.swap button:last-child:hover{
-    background: #1d2e38;
-    background: var(--cc-btn-primary-hover-bg);
+#c-bns.swap button:last-child:hover {
+  background: #1d2e38;
+  background: var(--cc-btn-primary-hover-bg);
 }
 
 #c-bns.swap button:first-child:active,
-#c-bns.swap button:first-child:hover{
-    background: #d8e0e6;
-    background: var(--cc-btn-secondary-hover-bg);
+#c-bns.swap button:first-child:hover {
+  background: #d8e0e6;
+  background: var(--cc-btn-secondary-hover-bg);
 }
 
-#s-hdr{
-    position: absolute;
-    top: 0;
-    width: 100%;
-    display: table;
-    padding: 0 2.1em;
-    height: 4.75em;
-    vertical-align: middle;
-    z-index: 2;
-    border-bottom: 1px solid #f1f3f5;
-    border-color: var(--cc-section-border);
+#s-hdr {
+  position: absolute;
+  top: 0;
+  width: 100%;
+  display: table;
+  padding: 0 2.1em;
+  height: 4.75em;
+  vertical-align: middle;
+  z-index: 2;
+  border-bottom: 1px solid #f1f3f5;
+  border-color: var(--cc-section-border);
 }
 
-#s-ttl{
-	display: table-cell;
-    vertical-align: middle;
-    font-size: 1em;
+#s-ttl {
+  display: table-cell;
+  vertical-align: middle;
+  font-size: 1em;
 }
 
-#s-c-bn{
-    padding: 0;
-    width: 1.7em;
-    height: 1.7em;
-    font-size: 1.45em;
-    margin: 0;
-    font-weight: initial;
-    position: relative;
+#s-c-bn {
+  padding: 0;
+  width: 1.7em;
+  height: 1.7em;
+  font-size: 1.45em;
+  margin: 0;
+  font-weight: initial;
+  position: relative;
 }
 
-#s-c-bnc{
-    display: table-cell;
-    vertical-align: middle;
+#s-c-bnc {
+  display: table-cell;
+  vertical-align: middle;
 }
 
 .cc_div span.t-lb {
-    position: absolute;
-    top: 0;
-    z-index: -1;
-    opacity: 0;
-    pointer-events: none;
-    overflow: hidden;
+  position: absolute;
+  top: 0;
+  z-index: -1;
+  opacity: 0;
+  pointer-events: none;
+  overflow: hidden;
 }
 
-#c_policy__text{
-    height: 31.250em;
-    overflow-y: auto;
-    margin-top: 1.250em;
+#c_policy__text {
+  height: 31.25em;
+  overflow-y: auto;
+  margin-top: 1.25em;
 }
 
-#c-s-in{
-    position: relative;
-    transform: translateY(-50%);
-    top: 50%;
-    height: 100%;
-    height: calc(100% - 2.5em);
-    max-height: 37.5em;
+#c-s-in {
+  position: relative;
+  transform: translateY(-50%);
+  top: 50%;
+  height: 100%;
+  height: calc(100% - 2.5em);
+  max-height: 37.5em;
 }
 
 @media screen and (min-width: 688px) {
-    /** works only on webkit-based browsers **/
-    #s-bl::-webkit-scrollbar{
-        width: .9em;
-        height: 100%;
-        background: transparent;
-        border-radius: 0 0.250em 0.250em 0;
-    }
-    
-    #s-bl::-webkit-scrollbar-thumb{
-        border: 0.25em solid var(--cc-bg);
-        background: #cfd5db;
-        background: var(--cc-webkit-scrollbar-bg);
-        border-radius: 100em;
-    }
+  /** works only on webkit-based browsers **/
+  #s-bl::-webkit-scrollbar {
+    width: 0.9em;
+    height: 100%;
+    background: transparent;
+    border-radius: 0 0.25em 0.25em 0;
+  }
 
-    #s-bl::-webkit-scrollbar-thumb:hover{
-        background: #9199a0;
-        background: var(--cc-webkit-scrollbar-bg-hover);
-    }
+  #s-bl::-webkit-scrollbar-thumb {
+    border: 0.25em solid var(--cc-bg);
+    background: #cfd5db;
+    background: var(--cc-webkit-scrollbar-bg);
+    border-radius: 100em;
+  }
 
-    #s-bl::-webkit-scrollbar-button {
-        width: 10px;
-        height: 5px;
-    }
+  #s-bl::-webkit-scrollbar-thumb:hover {
+    background: #9199a0;
+    background: var(--cc-webkit-scrollbar-bg-hover);
+  }
+
+  #s-bl::-webkit-scrollbar-button {
+    width: 10px;
+    height: 5px;
+  }
 }
 
 /** custom checkbox **/
 /* The container */
 .cc_div .b-tg {
-    position: absolute;
-    right: 0;
-    top: 0;
-    bottom: 0;
-    display: inline-block;
-    margin: auto;
-    right: 1.2em;
-    cursor: pointer;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;  
-    vertical-align: middle;
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  display: inline-block;
+  margin: auto;
+  right: 1.2em;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
 }
 
 /* Hide the browser's default checkbox */
 .cc_div .b-tg .c-tgl {
-    position: absolute;
-    cursor: pointer;
-    display: block;
-    top: 0;
-    left: 0;
-    margin: 0;
-    border: 0;
+  position: absolute;
+  cursor: pointer;
+  display: block;
+  top: 0;
+  left: 0;
+  margin: 0;
+  border: 0;
 }
 
 /* Create a custom checkbox */
 .cc_div .b-tg .c-tg {
-    position: absolute;
-    background: #919ea6;
-    background: var(--cc-toggle-bg-off);
-    transition: background-color .25s ease, box-shadow .25s ease;
-    pointer-events: none;
+  position: absolute;
+  background: #919ea6;
+  background: var(--cc-toggle-bg-off);
+  transition: background-color 0.25s ease, box-shadow 0.25s ease;
+  pointer-events: none;
 }
 
 .cc_div span.t-lb,
 .cc_div .b-tg,
 .cc_div .b-tg .c-tg,
-.cc_div .b-tg .c-tgl{
-    width: 3.4em;
-    height: 1.5em;
-    border-radius: 4em;
+.cc_div .b-tg .c-tgl {
+  width: 3.4em;
+  height: 1.5em;
+  border-radius: 4em;
 }
 
-.cc_div .b-tg .c-tg.c-ro{
-    cursor: not-allowed;
+.cc_div .b-tg .c-tg.c-ro {
+  cursor: not-allowed;
 }
 
-.cc_div .b-tg .c-tgl ~ .c-tg.c-ro{
-    background: #d5dee2;
-    background: var(--cc-toggle-bg-readonly);
+.cc_div .b-tg .c-tgl ~ .c-tg.c-ro {
+  background: #d5dee2;
+  background: var(--cc-toggle-bg-readonly);
 }
 
-.cc_div .b-tg .c-tgl ~ .c-tg.c-ro:after{
-    box-shadow: none;
+.cc_div .b-tg .c-tgl ~ .c-tg.c-ro:after {
+  box-shadow: none;
 }
 
 /* Style the checkmark/indicator */
 .cc_div .b-tg .c-tg:after {
-    content: "";
-    position: relative;
-    display: block;
-    left: 0.125em;
-    top: 0.125em;
-    width: 1.25em;
-    height: 1.25em;
-    border: none;
-    box-sizing: content-box;
-    background: #fff;
-    background: var(--cc-toggle-knob-bg);
-    box-shadow: 0 1px 2px rgba(24, 32, 35, .36);
-    transition: transform .25s ease;
-    border-radius: 100%;
+  content: "";
+  position: relative;
+  display: block;
+  left: 0.125em;
+  top: 0.125em;
+  width: 1.25em;
+  height: 1.25em;
+  border: none;
+  box-sizing: content-box;
+  background: #fff;
+  background: var(--cc-toggle-knob-bg);
+  box-shadow: 0 1px 2px rgba(24, 32, 35, 0.36);
+  transition: transform 0.25s ease;
+  border-radius: 100%;
 }
 
 /* Show the checkmark when checked */
-.cc_div .b-tg .c-tgl:checked ~ .c-tg:after{
-    transform: translateX(1.9em);
+.cc_div .b-tg .c-tgl:checked ~ .c-tg:after {
+  transform: translateX(1.9em);
 }
 
 #s-bl table,
 #s-bl th,
-#s-bl td{
-    border: none;
+#s-bl td {
+  border: none;
 }
 
-#s-bl tbody tr{
-    transition: background-color .25s ease;
+#s-bl tbody tr {
+  transition: background-color 0.25s ease;
 }
 
-#s-bl tbody tr:hover{
-    background: #e9eff4;
-    background: var(--cc-cookie-category-block-bg-hover);
+#s-bl tbody tr:hover {
+  background: #e9eff4;
+  background: var(--cc-cookie-category-block-bg-hover);
 }
 
-#s-bl table { 
-    text-align: left;
-    border-collapse: collapse;
-    width: 100%;
-    padding: 0;
-    margin: 0;
-    overflow: hidden;
+#s-bl table {
+  text-align: left;
+  border-collapse: collapse;
+  width: 100%;
+  padding: 0;
+  margin: 0;
+  overflow: hidden;
 }
 
-#s-bl td, 
-#s-bl th { 
-    padding: 0.8em 0.625em;
-    text-align: left;
-    vertical-align: top;
-    font-size: .8em;
-    padding-left: 1.2em;
+#s-bl td,
+#s-bl th {
+  padding: 0.8em 0.625em;
+  text-align: left;
+  vertical-align: top;
+  font-size: 0.8em;
+  padding-left: 1.2em;
 }
 
-#s-bl th { 
-	font-family: inherit;
-    padding: 1.2em 1.2em;
+#s-bl th {
+  font-family: inherit;
+  padding: 1.2em 1.2em;
 }
 
-#s-bl thead tr:first-child{
-    border-bottom: 1px solid #e9edf2;
-    border-color: var(--cc-cookie-table-border);
+#s-bl thead tr:first-child {
+  border-bottom: 1px solid #e9edf2;
+  border-color: var(--cc-cookie-table-border);
 }
 
 .force--consent #s-cnt,
-.force--consent #cs{
-    width: 100vw;
+.force--consent #cs {
+  width: 100vw;
 }
 
 #cm-ov,
-#cs-ov{
-    position: fixed;
-    left: 0;
-    right: 0;
-    top: 0;
-    bottom: 0;
-    visibility: hidden;
-    opacity: 0;
-    background: #070707;
-    background: rgba(4, 6, 8, .85);
-    background: var(--cc-overlay-bg);
-    display: none;
-    transition: none;
+#cs-ov {
+  position: fixed;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  visibility: hidden;
+  opacity: 0;
+  background: #070707;
+  background: rgba(4, 6, 8, 0.85);
+  background: var(--cc-overlay-bg);
+  display: none;
+  transition: none;
 }
 
 .show--settings #cs-ov,
 .c--anim #cs-ov,
 .force--consent .c--anim #cm-ov,
-.force--consent.show--consent #cm-ov{
-    display: block;
+.force--consent.show--consent #cm-ov {
+  display: block;
 }
 
-#cs-ov{
-    z-index: 2;
+#cs-ov {
+  z-index: 2;
 }
 
-.force--consent .cc_div{
-    position: fixed;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    width: 100%;
-    width: 100vw;
-    visibility: hidden;
-    transition: visibility .25s linear;
+.force--consent .cc_div {
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  width: 100vw;
+  visibility: hidden;
+  transition: visibility 0.25s linear;
 }
 
 .force--consent.show--consent .c--anim .cc_div,
-.force--consent.show--settings .c--anim .cc_div{
-    visibility: visible;
+.force--consent.show--settings .c--anim .cc_div {
+  visibility: visible;
 }
 
-.force--consent #cm{
-    position: absolute;
+.force--consent #cm {
+  position: absolute;
 }
 
-.force--consent #cm.bar{
-    width: 100vw;
-    max-width: 100vw;
+.force--consent #cm.bar {
+  width: 100vw;
+  max-width: 100vw;
 }
 
-html.force--consent.show--consent{
-    overflow-y: hidden!important;
+html.force--consent.show--consent {
+  overflow-y: hidden !important;
 }
 
 html.force--consent.show--consent,
-html.force--consent.show--consent body{
-    height: auto!important;
-    overflow-x: hidden!important;
+html.force--consent.show--consent body {
+  height: auto !important;
+  overflow-x: hidden !important;
 }
 /** END BLOCK PAGE SCROLL */
 
 /** BEGIN ICONS **/
 .cc_div .b-bn .exp::before,
-.cc_div .act .b-bn .exp::before{
-    border: solid #2d4156;
-    border-color: var(--cc-btn-secondary-text);
-    border-width: 0 2px 2px 0;
-    padding: .2em;
-    display: inline-block;
-    position: absolute;
-    content: '';
-    margin-right: 15px;
-    position: absolute;
-    transform: translateY(-50%) rotate(45deg);
-    left: 1.2em;
-    top: 50%;
+.cc_div .act .b-bn .exp::before {
+  border: solid #2d4156;
+  border-color: var(--cc-btn-secondary-text);
+  border-width: 0 2px 2px 0;
+  padding: 0.2em;
+  display: inline-block;
+  position: absolute;
+  content: "";
+  margin-right: 15px;
+  position: absolute;
+  transform: translateY(-50%) rotate(45deg);
+  left: 1.2em;
+  top: 50%;
 }
 
-.cc_div .act .b-bn .b-tl::before{
-    transform: translateY(-20%) rotate(225deg);
+.cc_div .act .b-bn .b-tl::before {
+  transform: translateY(-20%) rotate(225deg);
 }
 
-.cc_div .on-i::before{
-    border: solid #fff;
-    border-color: var(--cc-toggle-knob-icon-color);
-    border-width: 0 2px 2px 0;
-    padding: .1em;
-    display: inline-block;
-    padding-bottom: .45em;
-    content: '';
-    margin: 0 auto;
-    transform: rotate(45deg);
-    top: .37em;
-    left: .75em;
-    position: absolute;
+.cc_div .on-i::before {
+  border: solid #fff;
+  border-color: var(--cc-toggle-knob-icon-color);
+  border-width: 0 2px 2px 0;
+  padding: 0.1em;
+  display: inline-block;
+  padding-bottom: 0.45em;
+  content: "";
+  margin: 0 auto;
+  transform: rotate(45deg);
+  top: 0.37em;
+  left: 0.75em;
+  position: absolute;
 }
 
 #s-c-bn::before,
-#s-c-bn::after{
-    content: '';
-    position: absolute;
-    left: .82em;
-    top: .58em;
-    height: .6em;
-    width: 1.5px;
-    background: #444d53;
-    background: var(--cc-btn-secondary-text);
-    transform: rotate(45deg);
-    border-radius: 1em;
-    margin: 0 auto;
+#s-c-bn::after {
+  content: "";
+  position: absolute;
+  left: 0.82em;
+  top: 0.58em;
+  height: 0.6em;
+  width: 1.5px;
+  background: #444d53;
+  background: var(--cc-btn-secondary-text);
+  transform: rotate(45deg);
+  border-radius: 1em;
+  margin: 0 auto;
 }
 
-#s-c-bn::after{
-    transform: rotate(-45deg);
+#s-c-bn::after {
+  transform: rotate(-45deg);
 }
 
 .cc_div .off-i,
-.cc_div .on-i{
-    height: 100%;
-    width: 50%;
-    position: absolute;
-    right: 0;
-    display: block;
-    text-align: center;
-    transition: opacity .15s ease;
+.cc_div .on-i {
+  height: 100%;
+  width: 50%;
+  position: absolute;
+  right: 0;
+  display: block;
+  text-align: center;
+  transition: opacity 0.15s ease;
 }
 
-.cc_div .on-i{
-    left: 0;
-    opacity: 0;
+.cc_div .on-i {
+  left: 0;
+  opacity: 0;
 }
 
 .cc_div .off-i::before,
-.cc_div .off-i::after{
-    right: .8em;
-    top: .42em;
-    content: ' ';
-    height: .7em;
-    width: .09375em;
-    display: block;
-    background: #cdd6dc;
-    background: var(--cc-toggle-knob-icon-color);
-    margin: 0 auto;
-    position: absolute;
-    transform-origin: center;
+.cc_div .off-i::after {
+  right: 0.8em;
+  top: 0.42em;
+  content: " ";
+  height: 0.7em;
+  width: 0.09375em;
+  display: block;
+  background: #cdd6dc;
+  background: var(--cc-toggle-knob-icon-color);
+  margin: 0 auto;
+  position: absolute;
+  transform-origin: center;
 }
 
 .cc_div .off-i::before {
-    transform: rotate(45deg);
+  transform: rotate(45deg);
 }
 .cc_div .off-i::after {
-    transform: rotate(-45deg);
+  transform: rotate(-45deg);
 }
 
-.cc_div .b-tg .c-tgl:checked ~ .c-tg .on-i{
-    opacity: 1;
+.cc_div .b-tg .c-tgl:checked ~ .c-tg .on-i {
+  opacity: 1;
 }
-.cc_div .b-tg .c-tgl:checked ~ .c-tg .off-i{
-    opacity: 0;
+.cc_div .b-tg .c-tgl:checked ~ .c-tg .off-i {
+  opacity: 0;
 }
 /** END ICONS **/
 
 #cm.box.middle,
-#cm.cloud.middle{
-    top: 50%;
-    transform: translateY(-37%);
-    bottom: auto;
+#cm.cloud.middle {
+  top: 50%;
+  transform: translateY(-37%);
+  bottom: auto;
 }
 
 #cm.box.middle.zoom,
-#cm.cloud.middle.zoom{
-    transform: scale(.95) translateY(-50%);
+#cm.cloud.middle.zoom {
+  transform: scale(0.95) translateY(-50%);
 }
 
-#cm.box.center{
-    left: 1em;
-    right: 1em;
-    margin: 0 auto;
+#cm.box.center {
+  left: 1em;
+  right: 1em;
+  margin: 0 auto;
 }
 
 /* Start cloud layout */
 #cm.cloud {
-    max-width: 50em;
-    margin: 0 auto;
-    text-align: center;
-    left: 1em;
-    right: 1em;
-    overflow: hidden;
-    padding: 1.3em 2em;
-    width: unset;
+  max-width: 50em;
+  margin: 0 auto;
+  text-align: center;
+  left: 1em;
+  right: 1em;
+  overflow: hidden;
+  padding: 1.3em 2em;
+  width: unset;
 }
 
-.cc_div .cloud #c-inr{
-    display: table;
-    width: 100%;
+.cc_div .cloud #c-inr {
+  display: table;
+  width: 100%;
 }
 
-.cc_div .cloud #c-inr-i{
-    width: 70%;
-    display: table-cell;
-    vertical-align: top;
-    padding-right: 2.4em;
+.cc_div .cloud #c-inr-i {
+  width: 70%;
+  display: table-cell;
+  vertical-align: top;
+  padding-right: 2.4em;
 }
 
-.cc_div .cloud #c-txt{
-    font-size: 0.85em;
+.cc_div .cloud #c-txt {
+  font-size: 0.85em;
 }
 
-.cc_div .cloud #c-bns{
-    min-width: 170px;
-    display: table-cell;
-    vertical-align: middle;
+.cc_div .cloud #c-bns {
+  min-width: 170px;
+  display: table-cell;
+  vertical-align: middle;
 }
 
-#cm.cloud .c-bn{
-    margin: .625em 0 0 0;
-    width: 100%;
+.cloud #c-link {
+  min-width: 170px;
+  line-height: 30px;
+  display: table-row;
 }
 
-#cm.cloud .c-bn:first-child{
-    margin: 0;
+.cloud #c-link .cc-link {
+  vertical-align: bottom;
 }
 
-#cm.cloud.left{
-    margin-right: 1.25em;
+#cm.cloud .c-bn {
+  margin: 0.625em 0 0 0;
+  width: 100%;
 }
 
-#cm.cloud.right{
-    margin-left: 1.25em;
+#cm.cloud .c-bn:first-child {
+  margin: 0;
+}
+
+#cm.cloud.left {
+  margin-right: 1.25em;
+}
+
+#cm.cloud.right {
+  margin-left: 1.25em;
 }
 /* End cloud layout */
 
 /* Start bar layout */
 #cm.bar {
-    width: 100%;
-    max-width: 100%;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    border-radius: 0;
-    position: fixed;
-    padding: 2em;
+  width: 100%;
+  max-width: 100%;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border-radius: 0;
+  position: fixed;
+  padding: 2em;
 }
 
-#cm.bar #c-inr{
-    max-width: 32em;
-    margin: 0 auto;
+#cm.bar #c-inr {
+  max-width: 32em;
+  margin: 0 auto;
 }
 
-#cm.bar #c-bns{
-    max-width: 33.75em;
+#cm.bar #c-bns {
+  max-width: 33.75em;
 }
 
-#cm.bar #cs{
-    padding: 0;
+#cm.bar #cs {
+  padding: 0;
 }
 
-.cc_div .bar #c-s-in{
-    top: 0;
-    transform: none;
-    height: 100%;
-    max-height: 100%;
+.cc_div .bar #c-s-in {
+  top: 0;
+  transform: none;
+  height: 100%;
+  max-height: 100%;
 }
 
 .cc_div .bar #s-hdr,
 .cc_div .bar #s-bl,
 .cc_div .bar #s-bns {
-    padding-left: 1.6em;
-    padding-right: 1.6em;
+  padding-left: 1.6em;
+  padding-right: 1.6em;
 }
 
-.cc_div .bar #cs{
-    padding: 0;
+.cc_div .bar #cs {
+  padding: 0;
 }
 
 /* align bar to right by default */
-.cc_div .bar #s-inr{
-    margin: 0;
-    margin-left: auto;
-    margin-right: 0;
-    border-radius: 0;
-    max-width: 32em;
+.cc_div .bar #s-inr {
+  margin: 0;
+  margin-left: auto;
+  margin-right: 0;
+  border-radius: 0;
+  max-width: 32em;
 }
 
-.cc_div .bar.left #s-inr{
-    margin-left: 0;
-    margin-right: auto;
+.cc_div .bar.left #s-inr {
+  margin-left: 0;
+  margin-right: auto;
 }
 
 /* Force table to not be like tables anymore */
-.cc_div .bar #s-bl table, 
-.cc_div .bar #s-bl thead, 
-.cc_div .bar #s-bl tbody, 
-.cc_div .bar #s-bl th, 
-.cc_div .bar #s-bl td, 
+.cc_div .bar #s-bl table,
+.cc_div .bar #s-bl thead,
+.cc_div .bar #s-bl tbody,
+.cc_div .bar #s-bl th,
+.cc_div .bar #s-bl td,
 .cc_div .bar #s-bl tr,
-.cc_div .bar #s-cnt{ 
-    display: block; 
+.cc_div .bar #s-cnt {
+  display: block;
 }
 
 /* Hide table headers (but not display: none;, for accessibility) */
-.cc_div .bar #s-bl thead tr{ 
+.cc_div .bar #s-bl thead tr {
+  position: absolute;
+  top: -9999px;
+  left: -9999px;
+}
+
+.cc_div .bar #s-bl tr {
+  border-top: 1px solid #e3e7ed;
+  border-color: var(--cc-cookie-table-border);
+}
+
+.cc_div .bar #s-bl td {
+  /* Behave  like a "row" */
+  border: none;
+  position: relative;
+  padding-left: 35%;
+}
+
+.cc_div .bar #s-bl td:before {
+  position: absolute;
+  left: 1em;
+  padding-right: 0.625em;
+  white-space: nowrap;
+  content: attr(data-column);
+  color: #000;
+  color: var(--cc-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+/* End bar layout */
+
+/* Positions */
+#cm.top {
+  bottom: auto;
+  top: 1.25em;
+}
+
+#cm.left {
+  right: auto;
+  left: 1.25em;
+}
+
+#cm.right {
+  left: auto;
+  right: 1.25em;
+}
+
+#cm.bar.left,
+#cm.bar.right {
+  left: 0;
+  right: 0;
+}
+
+#cm.bar.top {
+  top: 0;
+}
+/* end positions */
+
+@media screen and (max-width: 688px) {
+  #cm,
+  #cm.cloud,
+  #cm.left,
+  #cm.right {
+    width: auto;
+    max-width: 100%;
+    margin: 0;
+    padding: 1.4em !important;
+    right: 1em;
+    left: 1em;
+    bottom: 1em;
+    display: block;
+  }
+
+  .force--consent #cm,
+  .force--consent #cm.cloud {
+    width: auto;
+    max-width: 100vw;
+  }
+
+  #cm.top {
+    top: 1em;
+    bottom: auto;
+  }
+
+  #cm.bottom {
+    bottom: 1em;
+    top: auto;
+  }
+
+  #cm.bar.bottom {
+    bottom: 0;
+  }
+
+  #cm.cloud .c-bn {
+    font-size: 0.85em;
+  }
+
+  #s-bns,
+  .cc_div .bar #s-bns {
+    padding: 1em 1.3em;
+  }
+
+  .cc_div .bar #s-inr {
+    max-width: 100%;
+    width: 100%;
+  }
+
+  .cc_div .cloud #c-inr-i {
+    padding-right: 0;
+  }
+
+  #cs {
+    border-radius: 0;
+    padding: 0;
+  }
+
+  #c-s-in {
+    max-height: 100%;
+    height: 100%;
+    top: 0;
+    transform: none;
+  }
+
+  .cc_div .b-tg {
+    transform: scale(1.1);
+    right: 1.1em;
+  }
+
+  #s-inr {
+    margin: 0;
+    padding-bottom: 7.9em;
+    border-radius: 0;
+  }
+
+  #s-bns {
+    height: 7.9em;
+  }
+
+  #s-bl,
+  .cc_div .bar #s-bl {
+    padding: 1.3em;
+  }
+
+  #s-hdr,
+  .cc_div .bar #s-hdr {
+    padding: 0 1.3em;
+  }
+
+  /** dynamic table layout **/
+  #s-bl table {
+    width: 100%;
+  }
+
+  #s-inr.bns-t {
+    padding-bottom: 10.5em;
+  }
+
+  .bns-t #s-bns {
+    height: 10.5em;
+  }
+
+  .cc_div .bns-t .c-bn {
+    font-size: 0.83em;
+    padding: 0.9em 1.6em;
+  }
+
+  #s-cnt .b-bn .b-tl {
+    padding-top: 1.2em;
+    padding-bottom: 1.2em;
+  }
+
+  /* Force table to not be like tables anymore */
+  #s-bl table,
+  #s-bl thead,
+  #s-bl tbody,
+  #s-bl th,
+  #s-bl td,
+  #s-bl tr,
+  #s-cnt {
+    display: block;
+  }
+
+  /* Hide table headers (but not display: none;, for accessibility) */
+  #s-bl thead tr {
     position: absolute;
     top: -9999px;
     left: -9999px;
-}
+  }
 
-.cc_div .bar #s-bl tr{
+  #s-bl tr {
     border-top: 1px solid #e3e7ed;
     border-color: var(--cc-cookie-table-border);
-}
+  }
 
-.cc_div .bar #s-bl td { 
+  #s-bl td {
     /* Behave  like a "row" */
     border: none;
     position: relative;
-    padding-left: 35%; 
-}
+    padding-left: 35%;
+  }
 
-.cc_div .bar #s-bl td:before { 
+  #s-bl td:before {
     position: absolute;
     left: 1em;
     padding-right: 0.625em;
@@ -1105,320 +1313,136 @@ html.force--consent.show--consent body{
     color: var(--cc-text);
     overflow: hidden;
     text-overflow: ellipsis;
-}
-/* End bar layout */
+  }
 
-/* Positions */
-#cm.top {
-    bottom: auto;
-    top: 1.250em;
-}
+  #cm .c-bn,
+  .cc_div .c-bn {
+    width: 100%;
+    margin-right: 0;
+  }
 
-#cm.left{
-    right: auto;
-    left: 1.250em;
-}
+  #s-cnt #s-rall-bn {
+    margin-left: 0;
+  }
 
-#cm.right{
-    left: auto;
-    right: 1.250em;
-}
+  .cc_div #c-bns {
+    flex-direction: column;
+  }
 
-#cm.bar.left,
-#cm.bar.right{
-    left: 0;
-    right: 0;
-}
+  #c-bns button + button,
+  #s-cnt button + button {
+    margin-top: 0.625em;
+    margin-left: 0;
+    float: unset;
+  }
 
-#cm.bar.top{
-    top: 0;
-}
-/* end positions */
+  #cm.cloud,
+  #cm.box {
+    left: 1em;
+    right: 1em;
+    width: auto;
+  }
 
-@media screen and (max-width: 688px) {
+  #cm.cloud.right,
+  #cm.cloud.left {
+    margin: 0;
+  }
 
-    #cm,
-    #cm.cloud,
-    #cm.left,
-    #cm.right{
-        width: auto;
-        max-width: 100%;
-        margin: 0;
-        padding: 1.4em!important;
-        right: 1em;
-        left: 1em;
-        bottom: 1em;
-        display: block;
-    }
+  .cc_div .cloud #c-bns,
+  .cc_div .cloud #c-inr,
+  .cc_div .cloud #c-inr-i {
+    display: block;
+    width: auto;
+    min-width: unset;
+  }
 
-    .force--consent #cm,
-    .force--consent #cm.cloud{
-        width: auto;
-        max-width: 100vw;
-    }
+  .cc_div .cloud #c-txt {
+    font-size: 0.9em;
+  }
 
-    #cm.top{
-        top: 1em;
-        bottom: auto;
-    }
-
-    #cm.bottom{
-        bottom: 1em;
-        top: auto;
-    }
-
-    #cm.bar.bottom{
-        bottom: 0;
-    }
-
-    #cm.cloud .c-bn{
-        font-size: .85em;
-    }
-
-    #s-bns,
-    .cc_div .bar #s-bns{
-        padding: 1em 1.3em;
-    }
-
-    .cc_div .bar #s-inr{
-        max-width: 100%;
-        width: 100%;
-    }
-
-    .cc_div .cloud #c-inr-i{
-        padding-right: 0;
-    }
-
-    #cs{
-        border-radius: 0;
-        padding: 0;
-    }
-
-    #c-s-in{
-        max-height: 100%;
-        height: 100%;
-        top: 0;
-        transform: none;
-    }
-
-    .cc_div .b-tg{
-        transform: scale(1.1);
-        right: 1.1em;
-    }
-
-    #s-inr{
-        margin: 0;
-        padding-bottom: 7.9em;
-        border-radius: 0;
-    }
-
-    #s-bns{
-        height: 7.9em;
-    }
-
-	#s-bl,
-    .cc_div .bar #s-bl{
-		padding: 1.3em;
-    }
-    
-	#s-hdr,
-    .cc_div .bar #s-hdr{
-        padding: 0 1.3em;
-    }
-
-    /** dynamic table layout **/
-    #s-bl table { 
-        width: 100%; 
-    }
-
-    #s-inr.bns-t{
-        padding-bottom: 10.5em;
-    }
-
-    .bns-t #s-bns{
-        height: 10.5em;
-    }
-
-    .cc_div .bns-t .c-bn{
-        font-size: 0.83em;
-        padding: .9em 1.6em;
-    }
-
-    #s-cnt .b-bn .b-tl{
-        padding-top: 1.2em;
-        padding-bottom: 1.2em;
-    }
-
-    /* Force table to not be like tables anymore */
-    #s-bl table, 
-    #s-bl thead, 
-    #s-bl tbody, 
-    #s-bl th, 
-    #s-bl td, 
-    #s-bl tr,
-    #s-cnt{ 
-        display: block; 
-    }
-
-    /* Hide table headers (but not display: none;, for accessibility) */
-    #s-bl thead tr{ 
-        position: absolute;
-        top: -9999px;
-        left: -9999px;
-    }
-
-    #s-bl tr{
-        border-top: 1px solid #e3e7ed;
-        border-color: var(--cc-cookie-table-border);
-    }
-
-    #s-bl td { 
-        /* Behave  like a "row" */
-        border: none;
-        position: relative;
-        padding-left: 35%; 
-    }
-
-    #s-bl td:before { 
-        position: absolute;
-        left: 1em;
-        padding-right: 0.625em;
-        white-space: nowrap;
-        content: attr(data-column);
-        color: #000;
-        color: var(--cc-text);
-        overflow: hidden;
-        text-overflow: ellipsis;
-    }
-
-    #cm .c-bn,
-    .cc_div .c-bn{
-        width: 100%;
-        margin-right: 0;
-    }
-
-    #s-cnt #s-rall-bn{
-        margin-left: 0;
-    }
-
-    .cc_div #c-bns{
-        flex-direction: column;
-    }
-
-    #c-bns button + button,
-    #s-cnt button + button{
-        margin-top: 0.625em;
-        margin-left: 0;
-        float: unset;
-    }
-
-    #cm.cloud,
-    #cm.box{
-        left: 1em;
-        right: 1em;
-        width: auto;
-    }
-
-    #cm.cloud.right,
-    #cm.cloud.left{
-        margin: 0;
-    }
-
-    .cc_div .cloud #c-bns,
-    .cc_div .cloud #c-inr,
-    .cc_div .cloud #c-inr-i{
-        display: block;
-        width: auto;
-        min-width: unset;
-    }
-
-    .cc_div .cloud #c-txt{
-        font-size: .9em;
-    }
-
-    .cc_div .cloud #c-bns{
-        margin-top: 1.625em;
-    }
+  .cc_div .cloud #c-bns {
+    margin-top: 1.625em;
+  }
 }
 
 /* Begin IE fixes */
-.cc_div.ie #c-vln{
-	height: 100%;
-	padding-top: 5.62em;
+.cc_div.ie #c-vln {
+  height: 100%;
+  padding-top: 5.62em;
 }
 
-.cc_div.ie .bar #c-vln{
-    padding-top: 0;
+.cc_div.ie .bar #c-vln {
+  padding-top: 0;
 }
 
-.cc_div.ie #cs{
-    max-height: 37.5em;
-    position: relative;
-	top: 0;
-	margin-top: -5.625em;
+.cc_div.ie #cs {
+  max-height: 37.5em;
+  position: relative;
+  top: 0;
+  margin-top: -5.625em;
 }
 
-.cc_div.ie .bar #cs{
-    margin-top:0;
-    max-height: 100%;
+.cc_div.ie .bar #cs {
+  margin-top: 0;
+  max-height: 100%;
 }
 
-.cc_div.ie #cm{
-    border: 1px solid #dee6e9;
+.cc_div.ie #cm {
+  border: 1px solid #dee6e9;
 }
 
-.cc_div.ie #c-s-in{
-    top: 0;
+.cc_div.ie #c-s-in {
+  top: 0;
 }
 
-.cc_div.ie .b-tg{
-	padding-left: 1em;
-	margin-bottom: 0.7em;
+.cc_div.ie .b-tg {
+  padding-left: 1em;
+  margin-bottom: 0.7em;
 }
 
-.cc_div.ie .b-tg .c-tgl:checked ~ .c-tg:after{
-    left: 1.95em;
+.cc_div.ie .b-tg .c-tgl:checked ~ .c-tg:after {
+  left: 1.95em;
 }
 
-.cc_div.ie #s-bl table{
-	overflow: auto;
+.cc_div.ie #s-bl table {
+  overflow: auto;
 }
 
-.cc_div.ie .b-tg .c-tg{
-    display: none;
+.cc_div.ie .b-tg .c-tg {
+  display: none;
 }
 
-.cc_div.ie .b-tg .c-tgl{
-    position: relative;
-    display: inline-block;
-    vertical-align: middle;
-    margin-bottom: 0.2em;
-    height: auto;
+.cc_div.ie .b-tg .c-tgl {
+  position: relative;
+  display: inline-block;
+  vertical-align: middle;
+  margin-bottom: 0.2em;
+  height: auto;
 }
 
-.cc_div.ie #s-cnt .b-bn .b-tl{
-    padding: 1.3em 6.4em 1.3em 1.4em
+.cc_div.ie #s-cnt .b-bn .b-tl {
+  padding: 1.3em 6.4em 1.3em 1.4em;
 }
 
-.cc_div.ie  .bar #s-bl td:before{
-    display: none;
+.cc_div.ie .bar #s-bl td:before {
+  display: none;
 }
 
-.cc_div.ie .bar #s-bl td{
-    padding: 0.8em 0.625em 0.8em 1.2em;
+.cc_div.ie .bar #s-bl td {
+  padding: 0.8em 0.625em 0.8em 1.2em;
 }
 
-.cc_div.ie .bar #s-bl thead tr{
-    position: relative;
+.cc_div.ie .bar #s-bl thead tr {
+  position: relative;
 }
 
-.cc_div.ie .b-tg .t-lb{
-    filter: alpha(opacity=0);
+.cc_div.ie .b-tg .t-lb {
+  filter: alpha(opacity=0);
 }
 
 .cc_div.ie #cm-ov,
-.cc_div.ie #cs-ov{
-    filter: alpha(opacity=80);
+.cc_div.ie #cs-ov {
+  filter: alpha(opacity=80);
 }
 
 /** END IE FIXES **/

--- a/src/cookieconsent.css
+++ b/src/cookieconsent.css
@@ -1372,6 +1372,19 @@ html.force--consent.show--consent body {
   .cc_div .cloud #c-bns {
     margin-top: 1.625em;
   }
+
+  .box #c-link,
+  .bar #c-link {
+    min-width: 170px;
+    line-height: 30px;
+    display: table-row;
+  }
+
+  .box #c-link .cc-link,
+  .bar #c-link .cc-link {
+    font-size: 0.9em;
+    vertical-align: bottom;
+  }
 }
 
 /* Begin IE fixes */

--- a/src/cookieconsent.css
+++ b/src/cookieconsent.css
@@ -279,7 +279,15 @@
 }
 
 #c-link .cc-link {
+  font-weight: 400;
   font-size: 0.9em;
+  width: 100%;
+  border-bottom: none;
+  text-decoration: underline;
+}
+
+#c-link .cc-link:first-child {
+  text-align: right;
 }
 
 #c-link .cc-link + .cc-link {
@@ -1012,6 +1020,7 @@ html.force--consent.show--consent body {
 }
 
 .cloud #c-link .cc-link {
+  font-size: 0.85em;
   vertical-align: bottom;
 }
 

--- a/src/cookieconsent.js
+++ b/src/cookieconsent.js
@@ -5,2437 +5,2619 @@
  * Released under the MIT License
  */
 (function () {
-  "use strict";
-  /**
-   * @param {HTMLElement} [root] - [optional] element where the cookieconsent will be appended
-   * @returns {Object} cookieconsent object with API
-   */
-  var CookieConsent = function (root) {
+    "use strict";
     /**
-     * CHANGE THIS FLAG FALSE TO DISABLE console.log()
+     * @param {HTMLElement} [root] - [optional] element where the cookieconsent will be appended
+     * @returns {Object} cookieconsent object with API
      */
-    var ENABLE_LOGS = true;
-
-    var _config = {
-      mode: "opt-in", // 'opt-in', 'opt-out'
-      current_lang: "en",
-      auto_language: null,
-      autorun: true, // run as soon as loaded
-      page_scripts: true,
-      hide_from_bots: true,
-      cookie_name: "cc_cookie",
-      cookie_expiration: 182, // default: 6 months (in days)
-      cookie_domain: window.location.hostname, // default: current domain
-      cookie_path: "/",
-      cookie_same_site: "Lax",
-      use_rfc_cookie: false,
-      autoclear_cookies: true,
-      revision: 0,
-      script_selector: "data-cookiecategory",
-    };
-
-    var /**
-       * Object which holds the main methods/API (.show, .run, ...)
-       */
-      _cookieconsent = {},
-      /**
-       * Global user configuration object
-       */
-      user_config,
-      /**
-       * Internal state variables
-       */
-      saved_cookie_content = {},
-      cookie_data = null,
-      /**
-       * @type {Date}
-       */
-      consent_date,
-      /**
-       * @type {Date}
-       */
-      last_consent_update,
-      /**
-       * @type {string}
-       */
-      consent_uuid,
-      /**
-       * @type {boolean}
-       */
-      invalid_consent = true,
-      consent_modal_exists = false,
-      consent_modal_visible = false,
-      settings_modal_visible = false,
-      clicked_inside_modal = false,
-      current_modal_focusable,
-      all_table_headers,
-      all_blocks,
-      // Helper callback functions
-      // (avoid calling "user_config['onAccept']" all the time)
-      onAccept,
-      onChange,
-      onFirstAction,
-      revision_enabled = false,
-      valid_revision = true,
-      revision_message = "",
-      // State variables for the autoclearCookies function
-      changed_settings = [],
-      reload_page = false;
-
-    /**
-     * Accept type:
-     *  - "all"
-     *  - "necessary"
-     *  - "custom"
-     * @type {string}
-     */
-    var accept_type;
-
-    /**
-     * Contains all accepted categories
-     * @type {string[]}
-     */
-    var accepted_categories = [];
-
-    /**
-     * Contains all non-accepted (rejected) categories
-     * @type {string[]}
-     */
-    var rejected_categories = [];
-
-    /**
-     * Contains all categories enabled by default
-     * @type {string[]}
-     */
-    var default_enabled_categories = [];
-
-    // Don't run plugin (to avoid indexing its text content) if bot detected
-    var is_bot = false;
-
-    /**
-     * Save reference to the last focused element on the page
-     * (used later to restore focus when both modals are closed)
-     */
-    var last_elem_before_modal;
-    var last_consent_modal_btn_focus;
-
-    /**
-     * Both of the arrays below have the same structure:
-     * [0] => holds reference to the FIRST focusable element inside modal
-     * [1] => holds reference to the LAST focusable element inside modal
-     */
-    var consent_modal_focusable = [];
-    var settings_modal_focusable = [];
-
-    /**
-     * Keep track of enabled/disabled categories
-     * @type {boolean[]}
-     */
-    var toggle_states = [];
-
-    /**
-     * Stores all available categories
-     * @type {string[]}
-     */
-    var all_categories = [];
-
-    /**
-     * Keep track of readonly toggles
-     * @type {boolean[]}
-     */
-    var readonly_categories = [];
-
-    /**
-     * Pointers to main dom elements (to avoid retrieving them later using document.getElementById)
-     */
-    var /** @type {HTMLElement} */ html_dom = document.documentElement,
-      /** @type {HTMLElement} */ main_container,
-      /** @type {HTMLElement} */ all_modals_container,
-      /** @type {HTMLElement} */ consent_modal,
-      /** @type {HTMLElement} */ consent_modal_title,
-      /** @type {HTMLElement} */ consent_modal_description,
-      /** @type {HTMLElement} */ consent_primary_btn,
-      /** @type {HTMLElement} */ consent_secondary_btn,
-      /** @type {HTMLElement} */ consent_buttons,
-      /** @type {HTMLElement} */ consent_modal_inner,
-      /** @type {HTMLElement} */ settings_container,
-      /** @type {HTMLElement} */ settings_inner,
-      /** @type {HTMLElement} */ settings_title,
-      /** @type {HTMLElement} */ settings_close_btn,
-      /** @type {HTMLElement} */ settings_blocks,
-      /** @type {HTMLElement} */ new_settings_blocks,
-      /** @type {HTMLElement} */ settings_buttons,
-      /** @type {HTMLElement} */ settings_save_btn,
-      /** @type {HTMLElement} */ settings_accept_all_btn,
-      /** @type {HTMLElement} */ settings_reject_all_btn,
-      /** @type {HTMLElement} */ consent_links_imprint,
-      /** @type {HTMLElement} */ consent_links_privacy,
-      /** @type {HTMLElement} */ consent_links,
-      /** @type {HTMLElement} */ privacy_policy_link,
-      /** @type {HTMLElement} */ imprint_link;
-
-    /**
-     * Update config settings
-     * @param {Object} user_config
-     */
-    var _setConfig = function (_user_config) {
-      /**
-       * Make user configuration globally available
-       */
-      user_config = _user_config;
-
-      _log("CookieConsent [CONFIG]: received_config_settings ", user_config);
-
-      if (typeof user_config["cookie_expiration"] === "number")
-        _config.cookie_expiration = user_config["cookie_expiration"];
-
-      if (typeof user_config["cookie_necessary_only_expiration"] === "number")
-        _config.cookie_necessary_only_expiration =
-          user_config["cookie_necessary_only_expiration"];
-
-      if (typeof user_config["autorun"] === "boolean")
-        _config.autorun = user_config["autorun"];
-
-      if (typeof user_config["cookie_domain"] === "string")
-        _config.cookie_domain = user_config["cookie_domain"];
-
-      if (typeof user_config["cookie_same_site"] === "string")
-        _config.cookie_same_site = user_config["cookie_same_site"];
-
-      if (typeof user_config["cookie_path"] === "string")
-        _config.cookie_path = user_config["cookie_path"];
-
-      if (typeof user_config["cookie_name"] === "string")
-        _config.cookie_name = user_config["cookie_name"];
-
-      if (typeof user_config["onAccept"] === "function")
-        onAccept = user_config["onAccept"];
-
-      if (typeof user_config["onFirstAction"] === "function")
-        onFirstAction = user_config["onFirstAction"];
-
-      if (typeof user_config["onChange"] === "function")
-        onChange = user_config["onChange"];
-
-      if (user_config["mode"] === "opt-out") _config.mode = "opt-out";
-
-      if (typeof user_config["revision"] === "number") {
-        user_config["revision"] > -1 &&
-          (_config.revision = user_config["revision"]);
-        revision_enabled = true;
-      }
-
-      if (typeof user_config["autoclear_cookies"] === "boolean")
-        _config.autoclear_cookies = user_config["autoclear_cookies"];
-
-      if (user_config["use_rfc_cookie"] === true) _config.use_rfc_cookie = true;
-
-      if (user_config["hide_from_bots"] === true) {
-        is_bot =
-          navigator &&
-          ((navigator.userAgent &&
-            /bot|crawl|spider|slurp|teoma/i.test(navigator.userAgent)) ||
-            navigator.webdriver);
-      }
-
-      _config.page_scripts = user_config["page_scripts"] === true;
-
-      if (
-        user_config["auto_language"] === "browser" ||
-        user_config["auto_language"] === true
-      ) {
-        _config.auto_language = "browser";
-      } else if (user_config["auto_language"] === "document") {
-        _config.auto_language = "document";
-      }
-
-      _log(
-        "CookieConsent [LANG]: auto_language strategy is '" +
-          _config.auto_language +
-          "'"
-      );
-
-      _config.current_lang = _resolveCurrentLang(
-        user_config.languages,
-        user_config["current_lang"]
-      );
-    };
-
-    // /**
-    //  * Print consent date
-    //  */
-    // var _printConsentDateHTML = function(){
-    //     if(!consent_date) return;
-
-    //     var consent_date_elements = document.querySelectorAll('[data-cc="consent-date"]');
-    //     var last_consent_update_elements = document.querySelectorAll('[data-cc="last-consent-update"]');
-
-    //     for(var i=0; i<consent_date_elements.length; i++)
-    //         consent_date_elements[i].textContent = consent_date.toLocaleString();
-
-    //     for(var i=0; i<last_consent_update_elements.length; i++)
-    //         last_consent_update_elements[i].textContent = last_consent_update.toLocaleString();
-    // }
-
-    /**
-     * Add an onClick listeners to all html elements with data-cc attribute
-     */
-    var _addDataButtonListeners = function (elem) {
-      var _a = "accept-";
-
-      var show_settings = _getElements("c-settings");
-      var accept_all = _getElements(_a + "all");
-      var accept_necessary = _getElements(_a + "necessary");
-      var accept_custom_selection = _getElements(_a + "custom");
-
-      for (var i = 0; i < show_settings.length; i++) {
-        show_settings[i].setAttribute("aria-haspopup", "dialog");
-        _addEvent(show_settings[i], "click", function (event) {
-          event.preventDefault();
-          _cookieconsent.showSettings(0);
-        });
-      }
-
-      for (i = 0; i < accept_all.length; i++) {
-        _addEvent(accept_all[i], "click", function (event) {
-          _acceptAction(event, "all");
-        });
-      }
-
-      for (i = 0; i < accept_custom_selection.length; i++) {
-        _addEvent(accept_custom_selection[i], "click", function (event) {
-          _acceptAction(event);
-        });
-      }
-
-      for (i = 0; i < accept_necessary.length; i++) {
-        _addEvent(accept_necessary[i], "click", function (event) {
-          _acceptAction(event, []);
-        });
-      }
-
-      /**
-       * Return all elements with given data-cc role
-       * @param {string} data_role
-       * @returns {NodeListOf<Element>}
-       */
-      function _getElements(data_role) {
-        return (elem || document).querySelectorAll(
-          'a[data-cc="' + data_role + '"], button[data-cc="' + data_role + '"]'
-        );
-      }
-
-      /**
-       * Helper function: accept and then hide modals
-       * @param {PointerEvent} e source event
-       * @param {string} [accept_type]
-       */
-      function _acceptAction(e, accept_type) {
-        e.preventDefault();
-        _cookieconsent.accept(accept_type);
-        _cookieconsent.hideSettings();
-        _cookieconsent.hide();
-      }
-
-      //_printConsentDateHTML();
-    };
-
-    /**
-     * Get a valid language (at least 1 must be defined)
-     * @param {string} lang - desired language
-     * @param {Object} all_languages - all defined languages
-     * @returns {string} validated language
-     */
-    var _getValidatedLanguage = function (lang, all_languages) {
-      if (Object.prototype.hasOwnProperty.call(all_languages, lang)) {
-        return lang;
-      } else if (_getKeys(all_languages).length > 0) {
-        if (
-          Object.prototype.hasOwnProperty.call(
-            all_languages,
-            _config.current_lang
-          )
-        ) {
-          return _config.current_lang;
-        } else {
-          return _getKeys(all_languages)[0];
-        }
-      }
-    };
-
-    /**
-     * Save reference to first and last focusable elements inside each modal
-     * to prevent losing focus while navigating with TAB
-     */
-    var _getModalFocusableData = function () {
-      /**
-       * Note: any of the below focusable elements, which has the attribute tabindex="-1" AND is either
-       * the first or last element of the modal, won't receive focus during "open/close" modal
-       */
-      var allowed_focusable_types = [
-        "[href]",
-        "button",
-        "input",
-        "details",
-        '[tabindex="0"]',
-      ];
-
-      function _getAllFocusableElements(modal, _array) {
-        var focus_later = false,
-          focus_first = false;
-
-        // ie might throw exception due to complex unsupported selector => a:not([tabindex="-1"])
-        try {
-          var focusable_elems = modal.querySelectorAll(
-            allowed_focusable_types.join(':not([tabindex="-1"]), ')
-          );
-          var attr,
-            len = focusable_elems.length,
-            i = 0;
-
-          while (i < len) {
-            attr = focusable_elems[i].getAttribute("data-focus");
-
-            if (!focus_first && attr === "1") {
-              focus_first = focusable_elems[i];
-            } else if (attr === "0") {
-              focus_later = focusable_elems[i];
-              if (
-                !focus_first &&
-                focusable_elems[i + 1].getAttribute("data-focus") !== "0"
-              ) {
-                focus_first = focusable_elems[i + 1];
-              }
-            }
-
-            i++;
-          }
-        } catch (e) {
-          return modal.querySelectorAll(allowed_focusable_types.join(", "));
-        }
-
+    var CookieConsent = function (root) {
         /**
-         * Save first and last elements (used to lock/trap focus inside modal)
+         * CHANGE THIS FLAG FALSE TO DISABLE console.log()
          */
-        _array[0] = focusable_elems[0];
-        _array[1] = focusable_elems[focusable_elems.length - 1];
-        _array[2] = focus_later;
-        _array[3] = focus_first;
-      }
+        var ENABLE_LOGS = true;
 
-      /**
-       * Get settings modal'S all focusable elements
-       * Save first and last elements (used to lock/trap focus inside modal)
-       */
-      _getAllFocusableElements(settings_inner, settings_modal_focusable);
+        var _config = {
+            mode: "opt-in", // 'opt-in', 'opt-out'
+            current_lang: "en",
+            auto_language: null,
+            autorun: true, // run as soon as loaded
+            page_scripts: true,
+            hide_from_bots: true,
+            cookie_name: "cc_cookie",
+            cookie_expiration: 182, // default: 6 months (in days)
+            cookie_domain: window.location.hostname, // default: current domain
+            cookie_path: "/",
+            cookie_same_site: "Lax",
+            use_rfc_cookie: false,
+            autoclear_cookies: true,
+            revision: 0,
+            script_selector: "data-cookiecategory",
+        };
 
-      /**
-       * If consent modal exists, do the same
-       */
-      if (consent_modal_exists) {
-        _getAllFocusableElements(consent_modal, consent_modal_focusable);
-      }
-    };
-
-    var _createConsentModal = function (lang) {
-      if (user_config["force_consent"] === true)
-        _addClass(html_dom, "force--consent");
-
-      // Create modal if it doesn't exist
-      if (!consent_modal) {
-        consent_modal = _createNode("div");
-        var consent_modal_inner_inner = _createNode("div");
-        var overlay = _createNode("div");
-
-        consent_modal.id = "cm";
-        consent_modal_inner_inner.id = "c-inr-i";
-        overlay.id = "cm-ov";
-
-        consent_modal.setAttribute("role", "dialog");
-        consent_modal.setAttribute("aria-modal", "true");
-        consent_modal.setAttribute("aria-hidden", "false");
-        consent_modal.setAttribute("aria-labelledby", "c-ttl");
-        consent_modal.setAttribute("aria-describedby", "c-txt");
-
-        // Append consent modal to main container
-        all_modals_container.appendChild(consent_modal);
-        all_modals_container.appendChild(overlay);
-
-        /**
-         * Make modal by default hidden to prevent weird page jumps/flashes (shown only once css is loaded)
-         */
-        consent_modal.style.visibility = overlay.style.visibility = "hidden";
-        overlay.style.opacity = 0;
-      }
-
-      // Use insertAdjacentHTML instead of innerHTML
-      var consent_modal_title_value =
-        user_config.languages[lang]["consent_modal"]["title"];
-
-      // Add title (if valid)
-      if (consent_modal_title_value) {
-        if (!consent_modal_title) {
-          consent_modal_title = _createNode("div");
-          consent_modal_title.id = "c-ttl";
-          consent_modal_title.setAttribute("role", "heading");
-          consent_modal_title.setAttribute("aria-level", "2");
-          consent_modal_inner_inner.appendChild(consent_modal_title);
-        }
-
-        consent_modal_title.innerHTML = consent_modal_title_value;
-      }
-
-      var description =
-        user_config.languages[lang]["consent_modal"]["description"];
-
-      if (revision_enabled) {
-        if (!valid_revision) {
-          description = description.replace(
-            "{{revision_message}}",
-            revision_message ||
-              user_config.languages[lang]["consent_modal"][
-                "revision_message"
-              ] ||
-              ""
-          );
-        } else {
-          description = description.replace("{{revision_message}}", "");
-        }
-      }
-
-      if (!consent_modal_description) {
-        consent_modal_description = _createNode("div");
-        consent_modal_description.id = "c-txt";
-        consent_modal_inner_inner.appendChild(consent_modal_description);
-      }
-
-      // Set description content
-      consent_modal_description.innerHTML = description;
-
-      var primary_btn_data =
-          user_config.languages[lang]["consent_modal"]["primary_btn"], // accept current selection
-        secondary_btn_data =
-          user_config.languages[lang]["consent_modal"]["secondary_btn"];
-
-      // Add primary button if not falsy
-      if (primary_btn_data) {
-        if (!consent_primary_btn) {
-          consent_primary_btn = _createNode("button");
-          consent_primary_btn.id = "c-p-bn";
-          consent_primary_btn.className = "c-bn";
-
-          var _accept_type;
-
-          if (primary_btn_data["role"] === "accept_all") _accept_type = "all";
-
-          _addEvent(consent_primary_btn, "click", function () {
-            _cookieconsent.hide();
-            _log("CookieConsent [ACCEPT]: cookie_consent was accepted!");
-            _cookieconsent.accept(_accept_type);
-          });
-        }
-
-        consent_primary_btn.innerHTML =
-          user_config.languages[lang]["consent_modal"]["primary_btn"]["text"];
-      }
-
-      // Add secondary button if not falsy
-      if (secondary_btn_data) {
-        if (!consent_secondary_btn) {
-          consent_secondary_btn = _createNode("button");
-          consent_secondary_btn.id = "c-s-bn";
-          consent_secondary_btn.className = "c-bn c_link";
-
-          if (secondary_btn_data["role"] === "accept_necessary") {
-            _addEvent(consent_secondary_btn, "click", function () {
-              _cookieconsent.hide();
-              _cookieconsent.accept([]); // accept necessary only
-            });
-          } else {
-            _addEvent(consent_secondary_btn, "click", function () {
-              _cookieconsent.showSettings(0);
-            });
-          }
-        }
-
-        consent_secondary_btn.innerHTML =
-          user_config.languages[lang]["consent_modal"]["secondary_btn"]["text"];
-      }
-
-      // Swap buttons
-      var gui_options_data = user_config["gui_options"];
-
-      if (!consent_modal_inner) {
-        consent_modal_inner = _createNode("div");
-        consent_modal_inner.id = "c-inr";
-
-        consent_modal_inner.appendChild(consent_modal_inner_inner);
-      }
-
-      if (!consent_buttons) {
-        consent_buttons = _createNode("div");
-        consent_buttons.id = "c-bns";
-
-        if (
-          gui_options_data &&
-          gui_options_data["consent_modal"] &&
-          gui_options_data["consent_modal"]["swap_buttons"] === true
-        ) {
-          secondary_btn_data &&
-            consent_buttons.appendChild(consent_secondary_btn);
-          primary_btn_data && consent_buttons.appendChild(consent_primary_btn);
-          consent_buttons.className = "swap";
-        } else {
-          primary_btn_data && consent_buttons.appendChild(consent_primary_btn);
-          secondary_btn_data &&
-            consent_buttons.appendChild(consent_secondary_btn);
-        }
-
-        (primary_btn_data || secondary_btn_data) &&
-          consent_modal_inner.appendChild(consent_buttons);
-        consent_modal.appendChild(consent_modal_inner);
-      }
-
-      // add links to privacy policy and imprint to modal
-      consent_links = _createNode("div");
-      consent_links.id = "c-link";
-
-      imprint_link =
-        user_config.languages[lang]["consent_modal"]["imprint_link"];
-      if (imprint_link) {
-        consent_links_imprint = _createNode("a");
-        consent_links_imprint.classList.add("cc-link");
-        consent_links_imprint.textContent = imprint_link["text"];
-        consent_links_imprint.setAttribute("href", imprint_link["url"]);
-        consent_links.appendChild(consent_links_imprint);
-      }
-
-      privacy_policy_link =
-        user_config.languages[lang]["consent_modal"]["privacy_policy_link"];
-      if (privacy_policy_link) {
-        consent_links_privacy = _createNode("a");
-        consent_links_privacy.classList.add("cc-link");
-        consent_links_privacy.textContent = privacy_policy_link["text"];
-        consent_links_privacy.setAttribute("href", privacy_policy_link["url"]);
-        consent_links.appendChild(consent_links_privacy);
-      }
-
-      consent_modal_inner.appendChild(consent_links);
-
-      consent_modal_exists = true;
-    };
-
-    var _createSettingsModal = function (lang) {
-      /**
-       * Create all consent_modal elements
-       */
-      if (!settings_container) {
-        settings_container = _createNode("div");
-        var settings_container_valign = _createNode("div");
-        var settings = _createNode("div");
-        var settings_container_inner = _createNode("div");
-        settings_inner = _createNode("div");
-        settings_title = _createNode("div");
-        var settings_header = _createNode("div");
-        settings_close_btn = _createNode("button");
-        var settings_close_btn_container = _createNode("div");
-        settings_blocks = _createNode("div");
-        var overlay = _createNode("div");
-
-        /**
-         * Set ids
-         */
-        settings_container.id = "s-cnt";
-        settings_container_valign.id = "c-vln";
-        settings_container_inner.id = "c-s-in";
-        settings.id = "cs";
-        settings_title.id = "s-ttl";
-        settings_inner.id = "s-inr";
-        settings_header.id = "s-hdr";
-        settings_blocks.id = "s-bl";
-        settings_close_btn.id = "s-c-bn";
-        overlay.id = "cs-ov";
-        settings_close_btn_container.id = "s-c-bnc";
-        settings_close_btn.className = "c-bn";
-
-        settings_container.setAttribute("role", "dialog");
-        settings_container.setAttribute("aria-modal", "true");
-        settings_container.setAttribute("aria-hidden", "true");
-        settings_container.setAttribute("aria-labelledby", "s-ttl");
-        settings_title.setAttribute("role", "heading");
-        settings_container.style.visibility = overlay.style.visibility =
-          "hidden";
-        overlay.style.opacity = 0;
-
-        settings_close_btn_container.appendChild(settings_close_btn);
-
-        // If 'esc' key is pressed inside settings_container div => hide settings
-        _addEvent(
-          settings_container_valign,
-          "keydown",
-          function (evt) {
-            evt = evt || window.event;
-            if (evt.keyCode === 27) {
-              _cookieconsent.hideSettings(0);
-            }
-          },
-          true
-        );
-
-        _addEvent(settings_close_btn, "click", function () {
-          _cookieconsent.hideSettings(0);
-        });
-      } else {
-        new_settings_blocks = _createNode("div");
-        new_settings_blocks.id = "s-bl";
-      }
-
-      // Add label to close button
-      settings_close_btn.setAttribute(
-        "aria-label",
-        user_config.languages[lang]["settings_modal"]["close_btn_label"] ||
-          "Close"
-      );
-
-      all_blocks = user_config.languages[lang]["settings_modal"]["blocks"];
-      all_table_headers =
-        user_config.languages[lang]["settings_modal"]["cookie_table_headers"];
-
-      var n_blocks = all_blocks.length;
-
-      // Set settings modal title
-      settings_title.innerHTML =
-        user_config.languages[lang]["settings_modal"]["title"];
-
-      // Create settings modal content (blocks)
-      for (var i = 0; i < n_blocks; ++i) {
-        var title_data = all_blocks[i]["title"],
-          description_data = all_blocks[i]["description"],
-          toggle_data = all_blocks[i]["toggle"],
-          cookie_table_data = all_blocks[i]["cookie_table"],
-          remove_cookie_tables = user_config["remove_cookie_tables"] === true,
-          isExpandable =
-            (description_data && "truthy") ||
-            (!remove_cookie_tables && cookie_table_data && "truthy");
-
-        // Create title
-        var block_section = _createNode("div");
-        var block_table_container = _createNode("div");
-
-        // Create description
-        if (description_data) {
-          var block_desc = _createNode("div");
-          block_desc.className = "p";
-          block_desc.insertAdjacentHTML("beforeend", description_data);
-        }
-
-        var block_title_container = _createNode("div");
-        block_title_container.className = "title";
-
-        block_section.className = "c-bl";
-        block_table_container.className = "desc";
-
-        // Create toggle if specified (opt in/out)
-        if (typeof toggle_data !== "undefined") {
-          var accordion_id = "c-ac-" + i;
-
-          // Create button (to collapse/expand block description)
-          var block_title_btn = isExpandable
-            ? _createNode("button")
-            : _createNode("div");
-          var block_switch_label = _createNode("label");
-          var block_switch = _createNode("input");
-          var block_switch_span = _createNode("span");
-          var label_text_span = _createNode("span");
-
-          // These 2 spans will contain each 2 pseudo-elements to generate 'tick' and 'x' icons
-          var block_switch_span_on_icon = _createNode("span");
-          var block_switch_span_off_icon = _createNode("span");
-
-          block_title_btn.className = isExpandable ? "b-tl exp" : "b-tl";
-          block_switch_label.className = "b-tg";
-          block_switch.className = "c-tgl";
-          block_switch_span_on_icon.className = "on-i";
-          block_switch_span_off_icon.className = "off-i";
-          block_switch_span.className = "c-tg";
-          label_text_span.className = "t-lb";
-
-          if (isExpandable) {
-            block_title_btn.setAttribute("aria-expanded", "false");
-            block_title_btn.setAttribute("aria-controls", accordion_id);
-          }
-
-          block_switch.type = "checkbox";
-          block_switch_span.setAttribute("aria-hidden", "true");
-
-          var cookie_category = toggle_data.value;
-          block_switch.value = cookie_category;
-
-          label_text_span.textContent = title_data;
-          block_title_btn.insertAdjacentHTML("beforeend", title_data);
-
-          block_title_container.appendChild(block_title_btn);
-          block_switch_span.appendChild(block_switch_span_on_icon);
-          block_switch_span.appendChild(block_switch_span_off_icon);
-
-          /**
-           * If consent is valid => retrieve category states from cookie
-           * Otherwise use states defined in the user_config. object
-           */
-          if (!invalid_consent) {
-            if (
-              _inArray(saved_cookie_content["categories"], cookie_category) > -1
-            ) {
-              block_switch.checked = true;
-              !new_settings_blocks && toggle_states.push(true);
-            } else {
-              !new_settings_blocks && toggle_states.push(false);
-            }
-          } else if (toggle_data["enabled"]) {
-            block_switch.checked = true;
-            !new_settings_blocks && toggle_states.push(true);
-
-            /**
-             * Keep track of categories enabled by default (useful when mode=='opt-out')
+        var /**
+             * Object which holds the main methods/API (.show, .run, ...)
              */
-            if (toggle_data["enabled"])
-              !new_settings_blocks &&
-                default_enabled_categories.push(cookie_category);
-          } else {
-            !new_settings_blocks && toggle_states.push(false);
-          }
-
-          !new_settings_blocks && all_categories.push(cookie_category);
-
-          /**
-           * Set toggle as readonly if true (disable checkbox)
-           */
-          if (toggle_data["readonly"]) {
-            block_switch.disabled = true;
-            _addClass(block_switch_span, "c-ro");
-            !new_settings_blocks && readonly_categories.push(true);
-          } else {
-            !new_settings_blocks && readonly_categories.push(false);
-          }
-
-          _addClass(block_table_container, "b-acc");
-          _addClass(block_title_container, "b-bn");
-          _addClass(block_section, "b-ex");
-
-          block_table_container.id = accordion_id;
-          block_table_container.setAttribute("aria-hidden", "true");
-
-          block_switch_label.appendChild(block_switch);
-          block_switch_label.appendChild(block_switch_span);
-          block_switch_label.appendChild(label_text_span);
-          block_title_container.appendChild(block_switch_label);
-
-          /**
-           * On button click handle the following :=> aria-expanded, aria-hidden and act class for current block
-           */
-          isExpandable &&
-            (function (accordion, block_section, btn) {
-              _addEvent(
-                block_title_btn,
-                "click",
-                function () {
-                  if (!_hasClass(block_section, "act")) {
-                    _addClass(block_section, "act");
-                    btn.setAttribute("aria-expanded", "true");
-                    accordion.setAttribute("aria-hidden", "false");
-                  } else {
-                    _removeClass(block_section, "act");
-                    btn.setAttribute("aria-expanded", "false");
-                    accordion.setAttribute("aria-hidden", "true");
-                  }
-                },
-                false
-              );
-            })(block_table_container, block_section, block_title_btn);
-        } else {
-          /**
-           * If block is not a button (no toggle defined),
-           * create a simple div instead
-           */
-          if (title_data) {
-            var block_title = _createNode("div");
-            block_title.className = "b-tl";
-            block_title.setAttribute("role", "heading");
-            block_title.setAttribute("aria-level", "3");
-            block_title.insertAdjacentHTML("beforeend", title_data);
-            block_title_container.appendChild(block_title);
-          }
-        }
-
-        title_data && block_section.appendChild(block_title_container);
-        description_data && block_table_container.appendChild(block_desc);
-
-        // if cookie table found, generate table for this block
-        if (!remove_cookie_tables && typeof cookie_table_data !== "undefined") {
-          var tr_tmp_fragment = document.createDocumentFragment();
-
-          /**
-           * Use custom table headers
-           */
-          for (var p = 0; p < all_table_headers.length; ++p) {
-            // create new header
-            var th1 = _createNode("th");
-            var obj = all_table_headers[p];
-            th1.setAttribute("scope", "col");
-
-            // get custom header content
-            if (obj) {
-              var new_column_key = obj && _getKeys(obj)[0];
-              th1.textContent = all_table_headers[p][new_column_key];
-              tr_tmp_fragment.appendChild(th1);
-            }
-          }
-
-          var tr_tmp = _createNode("tr");
-          tr_tmp.appendChild(tr_tmp_fragment);
-
-          // create table header & append fragment
-          var thead = _createNode("thead");
-          thead.appendChild(tr_tmp);
-
-          // append header to table
-          var block_table = _createNode("table");
-          block_table.appendChild(thead);
-
-          var tbody_fragment = document.createDocumentFragment();
-
-          // create table content
-          for (var n = 0; n < cookie_table_data.length; n++) {
-            var tr = _createNode("tr");
-
-            for (var g = 0; g < all_table_headers.length; ++g) {
-              // get custom header content
-              obj = all_table_headers[g];
-              if (obj) {
-                new_column_key = _getKeys(obj)[0];
-
-                var td_tmp = _createNode("td");
-
-                // Allow html inside table cells
-                td_tmp.insertAdjacentHTML(
-                  "beforeend",
-                  cookie_table_data[n][new_column_key]
-                );
-                td_tmp.setAttribute("data-column", obj[new_column_key]);
-
-                tr.appendChild(td_tmp);
-              }
-            }
-
-            tbody_fragment.appendChild(tr);
-          }
-
-          // append tbody_fragment to tbody & append the latter into the table
-          var tbody = _createNode("tbody");
-          tbody.appendChild(tbody_fragment);
-          block_table.appendChild(tbody);
-
-          block_table_container.appendChild(block_table);
-        }
-
-        /**
-         * Append only if is either:
-         * - togglable div with title
-         * - a simple div with at least a title or description
-         */
-        if (
-          (toggle_data && title_data) ||
-          (!toggle_data && (title_data || description_data))
-        ) {
-          block_section.appendChild(block_table_container);
-
-          if (new_settings_blocks)
-            new_settings_blocks.appendChild(block_section);
-          else settings_blocks.appendChild(block_section);
-        }
-      }
-
-      // Create settings buttons
-      if (!settings_buttons) {
-        settings_buttons = _createNode("div");
-        settings_buttons.id = "s-bns";
-      }
-
-      if (!settings_accept_all_btn) {
-        settings_accept_all_btn = _createNode("button");
-        settings_accept_all_btn.id = "s-all-bn";
-        settings_accept_all_btn.className = "c-bn";
-        settings_buttons.appendChild(settings_accept_all_btn);
-
-        _addEvent(settings_accept_all_btn, "click", function () {
-          _cookieconsent.hideSettings();
-          _cookieconsent.hide();
-          _cookieconsent.accept("all");
-        });
-      }
-
-      settings_accept_all_btn.innerHTML =
-        user_config.languages[lang]["settings_modal"]["accept_all_btn"];
-
-      var reject_all_btn_text =
-        user_config.languages[lang]["settings_modal"]["reject_all_btn"];
-
-      // Add third [optional] reject all button if provided
-      if (reject_all_btn_text) {
-        if (!settings_reject_all_btn) {
-          settings_reject_all_btn = _createNode("button");
-          settings_reject_all_btn.id = "s-rall-bn";
-          settings_reject_all_btn.className = "c-bn";
-
-          _addEvent(settings_reject_all_btn, "click", function () {
-            _cookieconsent.hideSettings();
-            _cookieconsent.hide();
-            _cookieconsent.accept([]);
-          });
-
-          settings_inner.className = "bns-t";
-          settings_buttons.appendChild(settings_reject_all_btn);
-        }
-
-        settings_reject_all_btn.innerHTML = reject_all_btn_text;
-      }
-
-      if (!settings_save_btn) {
-        settings_save_btn = _createNode("button");
-        settings_save_btn.id = "s-sv-bn";
-        settings_save_btn.className = "c-bn";
-        settings_buttons.appendChild(settings_save_btn);
-
-        // Add save preferences button onClick event
-        // Hide both settings modal and consent modal
-        _addEvent(settings_save_btn, "click", function () {
-          _cookieconsent.hideSettings();
-          _cookieconsent.hide();
-          _cookieconsent.accept();
-        });
-      }
-
-      settings_save_btn.innerHTML =
-        user_config.languages[lang]["settings_modal"]["save_settings_btn"];
-
-      if (new_settings_blocks) {
-        // replace entire existing cookie category blocks with the new cookie categories new blocks (in a different language)
-        settings_inner.replaceChild(new_settings_blocks, settings_blocks);
-        settings_blocks = new_settings_blocks;
-        return;
-      }
-
-      settings_header.appendChild(settings_title);
-      settings_header.appendChild(settings_close_btn_container);
-      settings_inner.appendChild(settings_header);
-      settings_inner.appendChild(settings_blocks);
-      settings_inner.appendChild(settings_buttons);
-      settings_container_inner.appendChild(settings_inner);
-
-      settings.appendChild(settings_container_inner);
-      settings_container_valign.appendChild(settings);
-      settings_container.appendChild(settings_container_valign);
-
-      all_modals_container.appendChild(settings_container);
-      all_modals_container.appendChild(overlay);
-    };
-
-    /**
-     * Generate cookie consent html markup
-     */
-    var _createCookieConsentHTML = function () {
-      // Create main container which holds both consent modal & settings modal
-      main_container = _createNode("div");
-      main_container.id = "cc--main";
-
-      // Fix layout flash
-      main_container.style.position = "fixed";
-      main_container.style.zIndex = "1000000";
-      main_container.innerHTML =
-        '<!--[if lt IE 9 ]><div id="cc_div" class="cc_div ie"></div><![endif]--><!--[if (gt IE 8)|!(IE)]><!--><div id="cc_div" class="cc_div"></div><!--<![endif]-->';
-      all_modals_container = main_container.children[0];
-
-      // Get current language
-      var lang = _config.current_lang;
-
-      // Create consent modal
-      if (consent_modal_exists) _createConsentModal(lang);
-
-      // Always create settings modal
-      _createSettingsModal(lang);
-
-      // Finally append everything (main_container holds both modals)
-      (root || document.body).appendChild(main_container);
-    };
-
-    /**
-     * Update/change modals language
-     * @param {String} lang new language
-     * @param {Boolean} [force] update language fields forcefully
-     * @returns {Boolean}
-     */
-    _cookieconsent.updateLanguage = function (lang, force) {
-      if (typeof lang !== "string") return;
-
-      /**
-       * Validate language to avoid errors
-       */
-      var new_validated_lang = _getValidatedLanguage(
-        lang,
-        user_config.languages
-      );
-
-      /**
-       * Set language only if it differs from current
-       */
-      if (new_validated_lang !== _config.current_lang || force === true) {
-        _config.current_lang = new_validated_lang;
-
-        if (consent_modal_exists) {
-          _createConsentModal(new_validated_lang);
-          _addDataButtonListeners(consent_modal_inner);
-        }
-
-        _createSettingsModal(new_validated_lang);
-
-        _log(
-          "CookieConsent [LANGUAGE]: curr_lang: '" + new_validated_lang + "'"
-        );
-
-        return true;
-      }
-
-      return false;
-    };
-
-    /**
-     * Delete all cookies which are unused (based on selected preferences)
-     *
-     * @param {boolean} [clearOnFirstAction]
-     */
-    var _autoclearCookies = function (clearOnFirstAction) {
-      // Get number of blocks
-      var len = all_blocks.length;
-      var count = -1;
-
-      // reset reload state
-      reload_page = false;
-
-      // Retrieve all cookies
-      var all_cookies_array = _getCookie("", "all");
-
-      // delete cookies on 'www.domain.com' and '.www.domain.com' (can also be without www)
-      var domains = [_config.cookie_domain, "." + _config.cookie_domain];
-
-      // if domain has www, delete cookies also for 'domain.com' and '.domain.com'
-      if (_config.cookie_domain.slice(0, 4) === "www.") {
-        var non_www_domain = _config.cookie_domain.substr(4); // remove first 4 chars (www.)
-        domains.push(non_www_domain);
-        domains.push("." + non_www_domain);
-      }
-
-      // For each block
-      for (var i = 0; i < len; i++) {
-        // Save current block (local scope & less accesses -> ~faster value retrieval)
-        var curr_block = all_blocks[i];
-
-        // If current block has a toggle for opt in/out
-        if (Object.prototype.hasOwnProperty.call(curr_block, "toggle")) {
-          // if current block has a cookie table, an off toggle,
-          // and its preferences were just changed => delete cookies
-          var category_just_disabled =
-            _inArray(changed_settings, curr_block["toggle"]["value"]) > -1;
-          if (
-            !toggle_states[++count] &&
-            Object.prototype.hasOwnProperty.call(curr_block, "cookie_table") &&
-            (clearOnFirstAction || category_just_disabled)
-          ) {
-            var curr_cookie_table = curr_block["cookie_table"];
-
-            // Get first property name
-            var ckey = _getKeys(all_table_headers[0])[0];
-
-            // Get number of cookies defined in cookie_table
-            var clen = curr_cookie_table.length;
-
-            // set "reload_page" to true if reload=on_disable
-            if (curr_block["toggle"]["reload"] === "on_disable")
-              category_just_disabled && (reload_page = true);
-
-            // for each row defined in the cookie table
-            for (var j = 0; j < clen; j++) {
-              // Get current row of table (corresponds to all cookie params)
-              var curr_row = curr_cookie_table[j],
-                found_cookies = [];
-              var curr_cookie_name = curr_row[ckey];
-              var is_regex = curr_row["is_regex"] || false;
-              var curr_cookie_domain = curr_row["domain"] || null;
-              var curr_cookie_path = curr_row["path"] || false;
-
-              // set domain to the specified domain
-              curr_cookie_domain &&
-                (domains = [curr_cookie_domain, "." + curr_cookie_domain]);
-
-              // If regex provided => filter cookie array
-              if (is_regex) {
-                for (var n = 0; n < all_cookies_array.length; n++) {
-                  if (all_cookies_array[n].match(curr_cookie_name)) {
-                    found_cookies.push(all_cookies_array[n]);
-                  }
-                }
-              } else {
-                var found_index = _inArray(all_cookies_array, curr_cookie_name);
-                if (found_index > -1)
-                  found_cookies.push(all_cookies_array[found_index]);
-              }
-
-              _log(
-                "CookieConsent [AUTOCLEAR]: search cookie: '" +
-                  curr_cookie_name +
-                  "', found:",
-                found_cookies
-              );
-
-              // If cookie exists -> delete it
-              if (found_cookies.length > 0) {
-                _eraseCookies(found_cookies, curr_cookie_path, domains);
-                curr_block["toggle"]["reload"] === "on_clear" &&
-                  (reload_page = true);
-              }
-            }
-          }
-        }
-      }
-    };
-
-    /**
-     * Set toggles/checkboxes based on accepted categories and save cookie
-     * @param {string[]} accepted_categories - Array of categories to accept
-     */
-    var _saveCookiePreferences = function (accepted_categories) {
-      changed_settings = [];
-
-      // Retrieve all toggle/checkbox values
-      var category_toggles = document.querySelectorAll(".c-tgl") || [];
-
-      // If there are opt in/out toggles ...
-      if (category_toggles.length > 0) {
-        for (var i = 0; i < category_toggles.length; i++) {
-          if (_inArray(accepted_categories, all_categories[i]) !== -1) {
-            category_toggles[i].checked = true;
-            if (!toggle_states[i]) {
-              changed_settings.push(all_categories[i]);
-              toggle_states[i] = true;
-            }
-          } else {
-            category_toggles[i].checked = false;
-            if (toggle_states[i]) {
-              changed_settings.push(all_categories[i]);
-              toggle_states[i] = false;
-            }
-          }
-        }
-      }
-
-      /**
-       * Clear cookies when settings/preferences change
-       */
-      if (
-        !invalid_consent &&
-        _config.autoclear_cookies &&
-        changed_settings.length > 0
-      )
-        _autoclearCookies();
-
-      if (!consent_date) consent_date = new Date();
-      if (!consent_uuid) consent_uuid = _uuidv4();
-
-      saved_cookie_content = {
-        categories: accepted_categories,
-        revision: _config.revision,
-        data: cookie_data,
-        rfc_cookie: _config.use_rfc_cookie,
-        consent_date: consent_date.toISOString(),
-        consent_uuid: consent_uuid,
-      };
-
-      // save cookie with preferences 'categories' (only if never accepted or settings were updated)
-      if (invalid_consent || changed_settings.length > 0) {
-        valid_revision = true;
-
-        /**
-         * Update "last_consent_update" only if it is invalid (after t)
-         */
-        if (!last_consent_update) last_consent_update = consent_date;
-        else last_consent_update = new Date();
-
-        saved_cookie_content["last_consent_update"] =
-          last_consent_update.toISOString();
-
-        /**
-         * Update accept type
-         */
-        accept_type = _getAcceptType(_getCurrentCategoriesState());
-
-        _setCookie(_config.cookie_name, JSON.stringify(saved_cookie_content));
-        _manageExistingScripts();
-
-        //_printConsentDateHTML();
-      }
-
-      if (invalid_consent) {
-        /**
-         * Delete unused/"zombie" cookies if consent is not valid (not yet expressed or cookie has expired)
-         */
-        if (_config.autoclear_cookies) _autoclearCookies(true);
-
-        if (typeof onFirstAction === "function")
-          onFirstAction(
-            _cookieconsent.getUserPreferences(),
-            saved_cookie_content
-          );
-
-        if (typeof onAccept === "function") onAccept(saved_cookie_content);
-
-        /**
-         * Set consent as valid
-         */
-        invalid_consent = false;
-
-        if (_config.mode === "opt-in") return;
-      }
-
-      // fire onChange only if settings were changed
-      if (typeof onChange === "function" && changed_settings.length > 0)
-        onChange(saved_cookie_content, changed_settings);
-
-      /**
-       * reload page if needed
-       */
-      if (reload_page) window.location.reload();
-    };
-
-    /**
-     * Returns index of found element inside array, otherwise -1
-     * @param {Array} arr
-     * @param {Object} value
-     * @returns {number}
-     */
-    var _inArray = function (arr, value) {
-      return arr.indexOf(value);
-    };
-
-    /**
-     * Helper function which prints info (console.log())
-     * @param {Object} print_msg
-     * @param {Object} [optional_param]
-     */
-    var _log = function (print_msg, optional_param, error) {
-      ENABLE_LOGS &&
-        (!error
-          ? console.log(
-              print_msg,
-              optional_param !== undefined ? optional_param : " "
-            )
-          : console.error(print_msg, optional_param || ""));
-    };
-
-    /**
-     * Helper function which creates an HTMLElement object based on 'type' and returns it.
-     * @param {string} type
-     * @returns {HTMLElement}
-     */
-    var _createNode = function (type) {
-      var el = document.createElement(type);
-      if (type === "button") {
-        el.setAttribute("type", type);
-      }
-      return el;
-    };
-
-    /**
-     * Generate RFC4122-compliant UUIDs.
-     * https://stackoverflow.com/questions/105034/how-to-create-a-guid-uuid?page=1&tab=votes#tab-top
-     * @returns {string}
-     */
-    var _uuidv4 = function () {
-      return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(
-        /[018]/g,
-        function (c) {
-          return (
-            c ^
-            ((window.crypto || window.msCrypto).getRandomValues(
-              new Uint8Array(1)
-            )[0] &
-              (15 >> (c / 4)))
-          ).toString(16);
-        }
-      );
-    };
-
-    /**
-     * Resolve which language should be used.
-     *
-     * @param {Object} languages Object with language translations
-     * @param {string} [requested_language] Language specified by given configuration parameters
-     * @returns {string}
-     */
-    var _resolveCurrentLang = function (languages, requested_language) {
-      if (_config.auto_language === "browser") {
-        return _getValidatedLanguage(_getBrowserLang(), languages);
-      } else if (_config.auto_language === "document") {
-        return _getValidatedLanguage(document.documentElement.lang, languages);
-      } else {
-        if (typeof requested_language === "string") {
-          return (_config.current_lang = _getValidatedLanguage(
-            requested_language,
-            languages
-          ));
-        }
-      }
-
-      _log(
-        "CookieConsent [LANG]: setting current_lang = '" +
-          _config.current_lang +
-          "'"
-      );
-      return _config.current_lang; // otherwise return default
-    };
-
-    /**
-     * Get current client's browser language
-     * @returns {string}
-     */
-    var _getBrowserLang = function () {
-      var browser_lang = navigator.language || navigator.browserLanguage;
-      browser_lang.length > 2 &&
-        (browser_lang = browser_lang[0] + browser_lang[1]);
-      _log(
-        "CookieConsent [LANG]: detected_browser_lang = '" + browser_lang + "'"
-      );
-      return browser_lang.toLowerCase();
-    };
-
-    /**
-     * Trap focus inside modal and focus the first
-     * focusable element of current active modal
-     */
-    var _handleFocusTrap = function () {
-      var tabbedOutsideDiv = false;
-      var tabbedInsideModal = false;
-
-      _addEvent(document, "keydown", function (e) {
-        e = e || window.event;
-
-        // If is tab key => ok
-        if (e.key !== "Tab") return;
-
-        // If there is any modal to focus
-        if (current_modal_focusable) {
-          // If reached natural end of the tab sequence => restart
-          if (e.shiftKey) {
-            if (document.activeElement === current_modal_focusable[0]) {
-              current_modal_focusable[1].focus();
-              e.preventDefault();
-            }
-          } else {
-            if (document.activeElement === current_modal_focusable[1]) {
-              current_modal_focusable[0].focus();
-              e.preventDefault();
-            }
-          }
-
-          // If have not yet used tab (or shift+tab) and modal is open ...
-          // Focus the first focusable element
-          if (!tabbedInsideModal && !clicked_inside_modal) {
-            tabbedInsideModal = true;
-            !tabbedOutsideDiv && e.preventDefault();
-
-            if (e.shiftKey) {
-              if (current_modal_focusable[3]) {
-                if (!current_modal_focusable[2]) {
-                  current_modal_focusable[0].focus();
-                } else {
-                  current_modal_focusable[2].focus();
-                }
-              } else {
-                current_modal_focusable[1].focus();
-              }
-            } else {
-              if (current_modal_focusable[3]) {
-                current_modal_focusable[3].focus();
-              } else {
-                current_modal_focusable[0].focus();
-              }
-            }
-          }
-        }
-
-        !tabbedInsideModal && (tabbedOutsideDiv = true);
-      });
-
-      if (document.contains) {
-        _addEvent(
-          main_container,
-          "click",
-          function (e) {
-            e = e || window.event;
+            _cookieconsent = {},
             /**
-             * If click is on the foreground overlay (and not inside settings_modal),
-             * hide settings modal
-             *
-             * Notice: click on div is not supported in IE
+             * Global user configuration object
              */
-            if (settings_modal_visible) {
-              if (!settings_inner.contains(e.target)) {
-                _cookieconsent.hideSettings(0);
-                clicked_inside_modal = false;
-              } else {
-                clicked_inside_modal = true;
-              }
-            } else if (consent_modal_visible) {
-              if (consent_modal.contains(e.target)) {
-                clicked_inside_modal = true;
-              }
-            }
-          },
-          true
-        );
-      }
-    };
+            user_config,
+            /**
+             * Internal state variables
+             */
+            saved_cookie_content = {},
+            cookie_data = null,
+            /**
+             * @type {Date}
+             */
+            consent_date,
+            /**
+             * @type {Date}
+             */
+            last_consent_update,
+            /**
+             * @type {string}
+             */
+            consent_uuid,
+            /**
+             * @type {boolean}
+             */
+            invalid_consent = true,
+            consent_modal_exists = false,
+            consent_modal_visible = false,
+            settings_modal_visible = false,
+            clicked_inside_modal = false,
+            current_modal_focusable,
+            all_table_headers,
+            all_blocks,
+            // Helper callback functions
+            // (avoid calling "user_config['onAccept']" all the time)
+            onAccept,
+            onChange,
+            onFirstAction,
+            revision_enabled = false,
+            valid_revision = true,
+            revision_message = "",
+            // State variables for the autoclearCookies function
+            changed_settings = [],
+            reload_page = false;
 
-    /**
-     * Manage each modal's layout
-     * @param {Object} gui_options
-     */
-    var _guiManager = function (gui_options, only_consent_modal) {
-      // If gui_options is not object => exit
-      if (typeof gui_options !== "object") return;
+        /**
+         * Accept type:
+         *  - "all"
+         *  - "necessary"
+         *  - "custom"
+         * @type {string}
+         */
+        var accept_type;
 
-      var consent_modal_options = gui_options["consent_modal"];
-      var settings_modal_options = gui_options["settings_modal"];
+        /**
+         * Contains all accepted categories
+         * @type {string[]}
+         */
+        var accepted_categories = [];
 
-      /**
-       * Helper function which adds layout and
-       * position classes to given modal
-       *
-       * @param {HTMLElement} modal
-       * @param {string[]} allowed_layouts
-       * @param {string[]} allowed_positions
-       * @param {string} layout
-       * @param {string[]} position
-       */
-      function _setLayout(
-        modal,
-        allowed_layouts,
-        allowed_positions,
-        allowed_transitions,
-        layout,
-        position,
-        transition
-      ) {
-        position = (position && position.split(" ")) || [];
+        /**
+         * Contains all non-accepted (rejected) categories
+         * @type {string[]}
+         */
+        var rejected_categories = [];
 
-        // Check if specified layout is valid
-        if (_inArray(allowed_layouts, layout) > -1) {
-          // Add layout classes
-          _addClass(modal, layout);
+        /**
+         * Contains all categories enabled by default
+         * @type {string[]}
+         */
+        var default_enabled_categories = [];
 
-          // Add position class (if specified)
-          if (
-            !(layout === "bar" && position[0] === "middle") &&
-            _inArray(allowed_positions, position[0]) > -1
-          ) {
-            for (var i = 0; i < position.length; i++) {
-              _addClass(modal, position[i]);
-            }
-          }
-        }
+        // Don't run plugin (to avoid indexing its text content) if bot detected
+        var is_bot = false;
 
-        // Add transition class
-        _inArray(allowed_transitions, transition) > -1 &&
-          _addClass(modal, transition);
-      }
+        /**
+         * Save reference to the last focused element on the page
+         * (used later to restore focus when both modals are closed)
+         */
+        var last_elem_before_modal;
+        var last_consent_modal_btn_focus;
 
-      if (consent_modal_exists && consent_modal_options) {
-        _setLayout(
-          consent_modal,
-          ["box", "bar", "cloud"],
-          ["top", "middle", "bottom"],
-          ["zoom", "slide"],
-          consent_modal_options["layout"],
-          consent_modal_options["position"],
-          consent_modal_options["transition"]
-        );
-      }
+        /**
+         * Both of the arrays below have the same structure:
+         * [0] => holds reference to the FIRST focusable element inside modal
+         * [1] => holds reference to the LAST focusable element inside modal
+         */
+        var consent_modal_focusable = [];
+        var settings_modal_focusable = [];
 
-      if (!only_consent_modal && settings_modal_options) {
-        _setLayout(
-          settings_container,
-          ["bar"],
-          ["left", "right"],
-          ["zoom", "slide"],
-          settings_modal_options["layout"],
-          settings_modal_options["position"],
-          settings_modal_options["transition"]
-        );
-      }
-    };
+        /**
+         * Keep track of enabled/disabled categories
+         * @type {boolean[]}
+         */
+        var toggle_states = [];
 
-    /**
-     * Returns true if cookie category is accepted by the user
-     * @param {string} cookie_category
-     * @returns {boolean}
-     */
-    _cookieconsent.allowedCategory = function (cookie_category) {
-      if (!invalid_consent || _config.mode === "opt-in")
-        var allowed_categories =
-          JSON.parse(_getCookie(_config.cookie_name, "one", true) || "{}")[
-            "categories"
-          ] || [];
-      // mode is 'opt-out'
-      else var allowed_categories = default_enabled_categories;
+        /**
+         * Stores all available categories
+         * @type {string[]}
+         */
+        var all_categories = [];
 
-      return _inArray(allowed_categories, cookie_category) > -1;
-    };
+        /**
+         * Keep track of readonly toggles
+         * @type {boolean[]}
+         */
+        var readonly_categories = [];
 
-    /**
-     * "Init" method. Will run once and only if modals do not exist
-     */
-    _cookieconsent.run = function (user_config) {
-      if (!document.getElementById("cc_div")) {
-        // configure all parameters
-        _setConfig(user_config);
+        /**
+         * Pointers to main dom elements (to avoid retrieving them later using document.getElementById)
+         */
+        var /** @type {HTMLElement} */ html_dom = document.documentElement,
+            /** @type {HTMLElement} */ main_container,
+            /** @type {HTMLElement} */ all_modals_container,
+            /** @type {HTMLElement} */ consent_modal,
+            /** @type {HTMLElement} */ consent_modal_title,
+            /** @type {HTMLElement} */ consent_modal_description,
+            /** @type {HTMLElement} */ consent_primary_btn,
+            /** @type {HTMLElement} */ consent_secondary_btn,
+            /** @type {HTMLElement} */ consent_buttons,
+            /** @type {HTMLElement} */ consent_modal_inner,
+            /** @type {HTMLElement} */ settings_container,
+            /** @type {HTMLElement} */ settings_inner,
+            /** @type {HTMLElement} */ settings_title,
+            /** @type {HTMLElement} */ settings_close_btn,
+            /** @type {HTMLElement} */ settings_blocks,
+            /** @type {HTMLElement} */ new_settings_blocks,
+            /** @type {HTMLElement} */ settings_buttons,
+            /** @type {HTMLElement} */ settings_save_btn,
+            /** @type {HTMLElement} */ settings_accept_all_btn,
+            /** @type {HTMLElement} */ settings_reject_all_btn,
+            /** @type {HTMLElement} */ consent_links_imprint,
+            /** @type {HTMLElement} */ consent_links_privacy,
+            /** @type {HTMLElement} */ consent_links,
+            /** @type {HTMLElement} */ privacy_policy_link,
+            /** @type {HTMLElement} */ imprint_link;
 
-        // if is bot, don't run plugin
-        if (is_bot) return;
+        /**
+         * Update config settings
+         * @param {Object} user_config
+         */
+        var _setConfig = function (_user_config) {
+            /**
+             * Make user configuration globally available
+             */
+            user_config = _user_config;
 
-        // Retrieve cookie value (if set)
-        saved_cookie_content = JSON.parse(
-          _getCookie(_config.cookie_name, "one", true) || "{}"
-        );
-
-        // Retrieve "consent_uuid"
-        consent_uuid = saved_cookie_content["consent_uuid"];
-
-        // If "consent_uuid" is present => assume that consent was previously given
-        var cookie_consent_accepted = consent_uuid !== undefined;
-
-        // Retrieve "consent_date"
-        consent_date = saved_cookie_content["consent_date"];
-        consent_date && (consent_date = new Date(consent_date));
-
-        // Retrieve "last_consent_update"
-        last_consent_update = saved_cookie_content["last_consent_update"];
-        last_consent_update &&
-          (last_consent_update = new Date(last_consent_update));
-
-        // Retrieve "data"
-        cookie_data =
-          saved_cookie_content["data"] !== undefined
-            ? saved_cookie_content["data"]
-            : null;
-
-        // If revision is enabled and current value !== saved value inside the cookie => revision is not valid
-        if (
-          revision_enabled &&
-          saved_cookie_content["revision"] !== _config.revision
-        ) {
-          valid_revision = false;
-        }
-
-        // If consent is not valid => create consent modal
-        consent_modal_exists = invalid_consent =
-          !cookie_consent_accepted ||
-          !valid_revision ||
-          !consent_date ||
-          !last_consent_update ||
-          !consent_uuid;
-
-        // Generate cookie-settings dom (& consent modal)
-        _createCookieConsentHTML();
-
-        _getModalFocusableData();
-        _guiManager(user_config["gui_options"]);
-        _addDataButtonListeners();
-
-        if (_config.autorun && consent_modal_exists) {
-          _cookieconsent.show(user_config["delay"] || 0);
-        }
-
-        // Add class to enable animations/transitions
-        setTimeout(function () {
-          _addClass(main_container, "c--anim");
-        }, 30);
-
-        // Accessibility :=> if tab pressed => trap focus inside modal
-        setTimeout(function () {
-          _handleFocusTrap();
-        }, 100);
-
-        // If consent is valid
-        if (!invalid_consent) {
-          var rfc_prop_exists =
-            typeof saved_cookie_content["rfc_cookie"] === "boolean";
-
-          /*
-           * Convert cookie to rfc format (if `use_rfc_cookie` is enabled)
-           */
-          if (
-            !rfc_prop_exists ||
-            (rfc_prop_exists &&
-              saved_cookie_content["rfc_cookie"] !== _config.use_rfc_cookie)
-          ) {
-            saved_cookie_content["rfc_cookie"] = _config.use_rfc_cookie;
-            _setCookie(
-              _config.cookie_name,
-              JSON.stringify(saved_cookie_content)
-            );
-          }
-
-          /**
-           * Update accept type
-           */
-          accept_type = _getAcceptType(_getCurrentCategoriesState());
-
-          _manageExistingScripts();
-
-          if (typeof onAccept === "function") onAccept(saved_cookie_content);
-
-          _log(
-            "CookieConsent [NOTICE]: consent already given!",
-            saved_cookie_content
-          );
-        } else {
-          if (_config.mode === "opt-out") {
             _log(
-              "CookieConsent [CONFIG] mode='" +
-                _config.mode +
-                "', default enabled categories:",
-              default_enabled_categories
+                "CookieConsent [CONFIG]: received_config_settings ",
+                user_config
             );
-            _manageExistingScripts(default_enabled_categories);
-          }
-          _log("CookieConsent [NOTICE]: ask for consent!");
-        }
-      } else {
-        _log(
-          "CookieConsent [NOTICE]: cookie consent already attached to body!"
-        );
-      }
-    };
 
-    /**
-     * Show settings modal (with optional delay)
-     * @param {number} delay
-     */
-    _cookieconsent.showSettings = function (delay) {
-      setTimeout(
-        function () {
-          _addClass(html_dom, "show--settings");
-          settings_container.setAttribute("aria-hidden", "false");
-          settings_modal_visible = true;
+            if (typeof user_config["cookie_expiration"] === "number")
+                _config.cookie_expiration = user_config["cookie_expiration"];
 
-          /**
-           * Set focus to the first focusable element inside settings modal
-           */
-          setTimeout(function () {
-            // If there is no consent-modal, keep track of the last focused elem.
-            if (!consent_modal_visible) {
-              last_elem_before_modal = document.activeElement;
-            } else {
-              last_consent_modal_btn_focus = document.activeElement;
+            if (
+                typeof user_config["cookie_necessary_only_expiration"] ===
+                "number"
+            )
+                _config.cookie_necessary_only_expiration =
+                    user_config["cookie_necessary_only_expiration"];
+
+            if (typeof user_config["autorun"] === "boolean")
+                _config.autorun = user_config["autorun"];
+
+            if (typeof user_config["cookie_domain"] === "string")
+                _config.cookie_domain = user_config["cookie_domain"];
+
+            if (typeof user_config["cookie_same_site"] === "string")
+                _config.cookie_same_site = user_config["cookie_same_site"];
+
+            if (typeof user_config["cookie_path"] === "string")
+                _config.cookie_path = user_config["cookie_path"];
+
+            if (typeof user_config["cookie_name"] === "string")
+                _config.cookie_name = user_config["cookie_name"];
+
+            if (typeof user_config["onAccept"] === "function")
+                onAccept = user_config["onAccept"];
+
+            if (typeof user_config["onFirstAction"] === "function")
+                onFirstAction = user_config["onFirstAction"];
+
+            if (typeof user_config["onChange"] === "function")
+                onChange = user_config["onChange"];
+
+            if (user_config["mode"] === "opt-out") _config.mode = "opt-out";
+
+            if (typeof user_config["revision"] === "number") {
+                user_config["revision"] > -1 &&
+                    (_config.revision = user_config["revision"]);
+                revision_enabled = true;
             }
 
-            if (settings_modal_focusable.length === 0) return;
+            if (typeof user_config["autoclear_cookies"] === "boolean")
+                _config.autoclear_cookies = user_config["autoclear_cookies"];
 
-            if (settings_modal_focusable[3]) {
-              settings_modal_focusable[3].focus();
-            } else {
-              settings_modal_focusable[0].focus();
-            }
-            current_modal_focusable = settings_modal_focusable;
-          }, 200);
+            if (user_config["use_rfc_cookie"] === true)
+                _config.use_rfc_cookie = true;
 
-          _log("CookieConsent [SETTINGS]: show settings_modal");
-        },
-        delay > 0 ? delay : 0
-      );
-    };
-
-    /**
-     * This function handles the loading/activation logic of the already
-     * existing scripts based on the current accepted cookie categories
-     *
-     * @param {string[]} [must_enable_categories]
-     */
-    var _manageExistingScripts = function (must_enable_categories) {
-      if (!_config.page_scripts) return;
-
-      // get all the scripts with "cookie-category" attribute
-      var scripts = document.querySelectorAll(
-        "script[" + _config.script_selector + "]"
-      );
-      var accepted_categories =
-        must_enable_categories || saved_cookie_content["categories"] || [];
-
-      /**
-       * Load scripts (sequentially), using a recursive function
-       * which loops through the scripts array
-       * @param {Element[]} scripts scripts to load
-       * @param {number} index current script to load
-       */
-      var _loadScripts = function (scripts, index) {
-        if (index < scripts.length) {
-          var curr_script = scripts[index];
-          var curr_script_category = curr_script.getAttribute(
-            _config.script_selector
-          );
-
-          /**
-           * If current script's category is on the array of categories
-           * accepted by the user => load script
-           */
-          if (_inArray(accepted_categories, curr_script_category) > -1) {
-            curr_script.type = "text/javascript";
-            curr_script.removeAttribute(_config.script_selector);
-
-            // get current script data-src
-            var src = curr_script.getAttribute("data-src");
-
-            // some scripts (like ga) might throw warning if data-src is present
-            src && curr_script.removeAttribute("data-src");
-
-            // create fresh script (with the same code)
-            var fresh_script = _createNode("script");
-            fresh_script.textContent = curr_script.innerHTML;
-
-            // Copy attributes over to the new "revived" script
-            (function (destination, source) {
-              var attributes = source.attributes;
-              var len = attributes.length;
-              for (var i = 0; i < len; i++) {
-                var attr_name = attributes[i].nodeName;
-                destination.setAttribute(
-                  attr_name,
-                  source[attr_name] || source.getAttribute(attr_name)
-                );
-              }
-            })(fresh_script, curr_script);
-
-            // set src (if data-src found)
-            src ? (fresh_script.src = src) : (src = curr_script.src);
-
-            // if script has "src" attribute
-            // try loading it sequentially
-            if (src) {
-              // load script sequentially => the next script will not be loaded
-              // until the current's script onload event triggers
-              if (fresh_script.readyState) {
-                // only required for IE <9
-                fresh_script.onreadystatechange = function () {
-                  if (
-                    fresh_script.readyState === "loaded" ||
-                    fresh_script.readyState === "complete"
-                  ) {
-                    fresh_script.onreadystatechange = null;
-                    _loadScripts(scripts, ++index);
-                  }
-                };
-              } else {
-                // others
-                fresh_script.onload = function () {
-                  fresh_script.onload = null;
-                  _loadScripts(scripts, ++index);
-                };
-              }
+            if (user_config["hide_from_bots"] === true) {
+                is_bot =
+                    navigator &&
+                    ((navigator.userAgent &&
+                        /bot|crawl|spider|slurp|teoma/i.test(
+                            navigator.userAgent
+                        )) ||
+                        navigator.webdriver);
             }
 
-            // Replace current "sleeping" script with the new "revived" one
-            curr_script.parentNode.replaceChild(fresh_script, curr_script);
+            _config.page_scripts = user_config["page_scripts"] === true;
 
-            /**
-             * If we managed to get here and scr is still set, it means that
-             * the script is loading/loaded sequentially so don't go any further
-             */
-            if (src) return;
-          }
-
-          // Go to next script right away
-          _loadScripts(scripts, ++index);
-        }
-      };
-
-      _loadScripts(scripts, 0);
-    };
-
-    /**
-     * Save custom data inside cookie
-     * @param {object|string} new_data
-     * @param {string} [mode]
-     * @returns {boolean}
-     */
-    var _setCookieData = function (new_data, mode) {
-      var set = false;
-      /**
-       * If mode is 'update':
-       * add/update only the specified props.
-       */
-      if (mode === "update") {
-        cookie_data = _cookieconsent.get("data");
-        var same_type = typeof cookie_data === typeof new_data;
-
-        if (same_type && typeof cookie_data === "object") {
-          !cookie_data && (cookie_data = {});
-
-          for (var prop in new_data) {
-            if (cookie_data[prop] !== new_data[prop]) {
-              cookie_data[prop] = new_data[prop];
-              set = true;
+            if (
+                user_config["auto_language"] === "browser" ||
+                user_config["auto_language"] === true
+            ) {
+                _config.auto_language = "browser";
+            } else if (user_config["auto_language"] === "document") {
+                _config.auto_language = "document";
             }
-          }
-        } else if ((same_type || !cookie_data) && cookie_data !== new_data) {
-          cookie_data = new_data;
-          set = true;
-        }
-      } else {
-        cookie_data = new_data;
-        set = true;
-      }
 
-      if (set) {
-        saved_cookie_content["data"] = cookie_data;
-        _setCookie(_config.cookie_name, JSON.stringify(saved_cookie_content));
-      }
+            _log(
+                "CookieConsent [LANG]: auto_language strategy is '" +
+                    _config.auto_language +
+                    "'"
+            );
 
-      return set;
-    };
+            _config.current_lang = _resolveCurrentLang(
+                user_config.languages,
+                user_config["current_lang"]
+            );
+        };
 
-    /**
-     * Helper method to set a variety of fields
-     * @param {string} field
-     * @param {object} data
-     * @returns {boolean}
-     */
-    _cookieconsent.set = function (field, data) {
-      switch (field) {
-        case "data":
-          return _setCookieData(data["value"], data["mode"]);
-        default:
-          return false;
-      }
-    };
+        // /**
+        //  * Print consent date
+        //  */
+        // var _printConsentDateHTML = function(){
+        //     if(!consent_date) return;
 
-    /**
-     * Retrieve data from existing cookie
-     * @param {string} field
-     * @param {string} [cookie_name]
-     * @returns {any}
-     */
-    _cookieconsent.get = function (field, cookie_name) {
-      var cookie = JSON.parse(
-        _getCookie(cookie_name || _config.cookie_name, "one", true) || "{}"
-      );
+        //     var consent_date_elements = document.querySelectorAll('[data-cc="consent-date"]');
+        //     var last_consent_update_elements = document.querySelectorAll('[data-cc="last-consent-update"]');
 
-      return cookie[field];
-    };
+        //     for(var i=0; i<consent_date_elements.length; i++)
+        //         consent_date_elements[i].textContent = consent_date.toLocaleString();
 
-    /**
-     * Read current configuration value
-     * @returns {any}
-     */
-    _cookieconsent.getConfig = function (field) {
-      return _config[field] || user_config[field];
-    };
-
-    /**
-     * Obtain accepted and rejected categories
-     * @returns {{accepted: string[], rejected: string[]}}
-     */
-    var _getCurrentCategoriesState = function () {
-      // get accepted categories
-      accepted_categories = saved_cookie_content["categories"] || [];
-
-      // calculate rejected categories (all_categories - accepted_categories)
-      rejected_categories = all_categories.filter(function (category) {
-        return _inArray(accepted_categories, category) === -1;
-      });
-
-      return {
-        accepted: accepted_categories,
-        rejected: rejected_categories,
-      };
-    };
-
-    /**
-     * Calculate "accept type" given current categories state
-     * @param {{accepted: string[], rejected: string[]}} currentCategoriesState
-     * @returns {string}
-     */
-    var _getAcceptType = function (currentCategoriesState) {
-      var type = "custom";
-
-      // number of categories marked as necessary/readonly
-      var necessary_categories_length = readonly_categories.filter(function (
-        readonly
-      ) {
-        return readonly === true;
-      }).length;
-
-      // calculate accept type based on accepted/rejected categories
-      if (currentCategoriesState.accepted.length === all_categories.length)
-        type = "all";
-      else if (
-        currentCategoriesState.accepted.length === necessary_categories_length
-      )
-        type = "necessary";
-
-      return type;
-    };
-
-    /**
-     * @typedef {object} userPreferences
-     * @property {string} accept_type
-     * @property {string[]} accepted_categories
-     * @property {string[]} rejected_categories
-     */
-
-    /**
-     * Retrieve current user preferences (summary)
-     * @returns {userPreferences}
-     */
-    _cookieconsent.getUserPreferences = function () {
-      var currentCategoriesState = _getCurrentCategoriesState();
-      var accept_type = _getAcceptType(currentCategoriesState);
-
-      return {
-        accept_type: accept_type,
-        accepted_categories: currentCategoriesState.accepted,
-        rejected_categories: currentCategoriesState.rejected,
-      };
-    };
-
-    /**
-     * Function which will run after script load
-     * @callback scriptLoaded
-     */
-
-    /**
-     * Dynamically load script (append to head)
-     * @param {string} src
-     * @param {scriptLoaded} callback
-     * @param {object[]} [attrs] Custom attributes
-     */
-    _cookieconsent.loadScript = function (src, callback, attrs) {
-      var function_defined = typeof callback === "function";
-
-      // Load script only if not already loaded
-      if (!document.querySelector('script[src="' + src + '"]')) {
-        var script = _createNode("script");
-
-        // if an array is provided => add custom attributes
-        if (attrs && attrs.length > 0) {
-          for (var i = 0; i < attrs.length; ++i) {
-            attrs[i] &&
-              script.setAttribute(attrs[i]["name"], attrs[i]["value"]);
-          }
-        }
-
-        // if callback function defined => run callback onload
-        if (function_defined) {
-          script.onload = callback;
-        }
-
-        script.src = src;
+        //     for(var i=0; i<last_consent_update_elements.length; i++)
+        //         last_consent_update_elements[i].textContent = last_consent_update.toLocaleString();
+        // }
 
         /**
-         * Append script to head
+         * Add an onClick listeners to all html elements with data-cc attribute
          */
-        document.head.appendChild(script);
-      } else {
-        function_defined && callback();
-      }
-    };
+        var _addDataButtonListeners = function (elem) {
+            var _a = "accept-";
 
-    /**
-     * Manage dynamically loaded scripts: https://github.com/orestbida/cookieconsent/issues/101
-     * If plugin has already run, call this method to enable
-     * the newly added scripts based on currently selected preferences
-     */
-    _cookieconsent.updateScripts = function () {
-      _manageExistingScripts();
-    };
+            var show_settings = _getElements("c-settings");
+            var accept_all = _getElements(_a + "all");
+            var accept_necessary = _getElements(_a + "necessary");
+            var accept_custom_selection = _getElements(_a + "custom");
 
-    /**
-     * Show cookie consent modal (with delay parameter)
-     * @param {number} [delay]
-     * @param {boolean} [create_modal] create modal if it doesn't exist
-     */
-    _cookieconsent.show = function (delay, create_modal) {
-      if (create_modal === true) _createConsentModal(_config.current_lang);
+            for (var i = 0; i < show_settings.length; i++) {
+                show_settings[i].setAttribute("aria-haspopup", "dialog");
+                _addEvent(show_settings[i], "click", function (event) {
+                    event.preventDefault();
+                    _cookieconsent.showSettings(0);
+                });
+            }
 
-      if (consent_modal_exists) {
-        setTimeout(
-          function () {
-            _addClass(html_dom, "show--consent");
+            for (i = 0; i < accept_all.length; i++) {
+                _addEvent(accept_all[i], "click", function (event) {
+                    _acceptAction(event, "all");
+                });
+            }
+
+            for (i = 0; i < accept_custom_selection.length; i++) {
+                _addEvent(
+                    accept_custom_selection[i],
+                    "click",
+                    function (event) {
+                        _acceptAction(event);
+                    }
+                );
+            }
+
+            for (i = 0; i < accept_necessary.length; i++) {
+                _addEvent(accept_necessary[i], "click", function (event) {
+                    _acceptAction(event, []);
+                });
+            }
 
             /**
-             * Update attributes/internal statuses
+             * Return all elements with given data-cc role
+             * @param {string} data_role
+             * @returns {NodeListOf<Element>}
              */
-            consent_modal.setAttribute("aria-hidden", "false");
-            consent_modal_visible = true;
+            function _getElements(data_role) {
+                return (elem || document).querySelectorAll(
+                    'a[data-cc="' +
+                        data_role +
+                        '"], button[data-cc="' +
+                        data_role +
+                        '"]'
+                );
+            }
+
+            /**
+             * Helper function: accept and then hide modals
+             * @param {PointerEvent} e source event
+             * @param {string} [accept_type]
+             */
+            function _acceptAction(e, accept_type) {
+                e.preventDefault();
+                _cookieconsent.accept(accept_type);
+                _cookieconsent.hideSettings();
+                _cookieconsent.hide();
+            }
+
+            //_printConsentDateHTML();
+        };
+
+        /**
+         * Get a valid language (at least 1 must be defined)
+         * @param {string} lang - desired language
+         * @param {Object} all_languages - all defined languages
+         * @returns {string} validated language
+         */
+        var _getValidatedLanguage = function (lang, all_languages) {
+            if (Object.prototype.hasOwnProperty.call(all_languages, lang)) {
+                return lang;
+            } else if (_getKeys(all_languages).length > 0) {
+                if (
+                    Object.prototype.hasOwnProperty.call(
+                        all_languages,
+                        _config.current_lang
+                    )
+                ) {
+                    return _config.current_lang;
+                } else {
+                    return _getKeys(all_languages)[0];
+                }
+            }
+        };
+
+        /**
+         * Save reference to first and last focusable elements inside each modal
+         * to prevent losing focus while navigating with TAB
+         */
+        var _getModalFocusableData = function () {
+            /**
+             * Note: any of the below focusable elements, which has the attribute tabindex="-1" AND is either
+             * the first or last element of the modal, won't receive focus during "open/close" modal
+             */
+            var allowed_focusable_types = [
+                "[href]",
+                "button",
+                "input",
+                "details",
+                '[tabindex="0"]',
+            ];
+
+            function _getAllFocusableElements(modal, _array) {
+                var focus_later = false,
+                    focus_first = false;
+
+                // ie might throw exception due to complex unsupported selector => a:not([tabindex="-1"])
+                try {
+                    var focusable_elems = modal.querySelectorAll(
+                        allowed_focusable_types.join(':not([tabindex="-1"]), ')
+                    );
+                    var attr,
+                        len = focusable_elems.length,
+                        i = 0;
+
+                    while (i < len) {
+                        attr = focusable_elems[i].getAttribute("data-focus");
+
+                        if (!focus_first && attr === "1") {
+                            focus_first = focusable_elems[i];
+                        } else if (attr === "0") {
+                            focus_later = focusable_elems[i];
+                            if (
+                                !focus_first &&
+                                focusable_elems[i + 1].getAttribute(
+                                    "data-focus"
+                                ) !== "0"
+                            ) {
+                                focus_first = focusable_elems[i + 1];
+                            }
+                        }
+
+                        i++;
+                    }
+                } catch (e) {
+                    return modal.querySelectorAll(
+                        allowed_focusable_types.join(", ")
+                    );
+                }
+
+                /**
+                 * Save first and last elements (used to lock/trap focus inside modal)
+                 */
+                _array[0] = focusable_elems[0];
+                _array[1] = focusable_elems[focusable_elems.length - 1];
+                _array[2] = focus_later;
+                _array[3] = focus_first;
+            }
+
+            /**
+             * Get settings modal'S all focusable elements
+             * Save first and last elements (used to lock/trap focus inside modal)
+             */
+            _getAllFocusableElements(settings_inner, settings_modal_focusable);
+
+            /**
+             * If consent modal exists, do the same
+             */
+            if (consent_modal_exists) {
+                _getAllFocusableElements(
+                    consent_modal,
+                    consent_modal_focusable
+                );
+            }
+        };
+
+        var _createConsentModal = function (lang) {
+            if (user_config["force_consent"] === true)
+                _addClass(html_dom, "force--consent");
+
+            // Create modal if it doesn't exist
+            if (!consent_modal) {
+                consent_modal = _createNode("div");
+                var consent_modal_inner_inner = _createNode("div");
+                var overlay = _createNode("div");
+
+                consent_modal.id = "cm";
+                consent_modal_inner_inner.id = "c-inr-i";
+                overlay.id = "cm-ov";
+
+                consent_modal.setAttribute("role", "dialog");
+                consent_modal.setAttribute("aria-modal", "true");
+                consent_modal.setAttribute("aria-hidden", "false");
+                consent_modal.setAttribute("aria-labelledby", "c-ttl");
+                consent_modal.setAttribute("aria-describedby", "c-txt");
+
+                // Append consent modal to main container
+                all_modals_container.appendChild(consent_modal);
+                all_modals_container.appendChild(overlay);
+
+                /**
+                 * Make modal by default hidden to prevent weird page jumps/flashes (shown only once css is loaded)
+                 */
+                consent_modal.style.visibility = overlay.style.visibility =
+                    "hidden";
+                overlay.style.opacity = 0;
+            }
+
+            // Use insertAdjacentHTML instead of innerHTML
+            var consent_modal_title_value =
+                user_config.languages[lang]["consent_modal"]["title"];
+
+            // Add title (if valid)
+            if (consent_modal_title_value) {
+                if (!consent_modal_title) {
+                    consent_modal_title = _createNode("div");
+                    consent_modal_title.id = "c-ttl";
+                    consent_modal_title.setAttribute("role", "heading");
+                    consent_modal_title.setAttribute("aria-level", "2");
+                    consent_modal_inner_inner.appendChild(consent_modal_title);
+                }
+
+                consent_modal_title.innerHTML = consent_modal_title_value;
+            }
+
+            var description =
+                user_config.languages[lang]["consent_modal"]["description"];
+
+            if (revision_enabled) {
+                if (!valid_revision) {
+                    description = description.replace(
+                        "{{revision_message}}",
+                        revision_message ||
+                            user_config.languages[lang]["consent_modal"][
+                                "revision_message"
+                            ] ||
+                            ""
+                    );
+                } else {
+                    description = description.replace(
+                        "{{revision_message}}",
+                        ""
+                    );
+                }
+            }
+
+            if (!consent_modal_description) {
+                consent_modal_description = _createNode("div");
+                consent_modal_description.id = "c-txt";
+                consent_modal_inner_inner.appendChild(
+                    consent_modal_description
+                );
+            }
+
+            // Set description content
+            consent_modal_description.innerHTML = description;
+
+            var primary_btn_data =
+                    user_config.languages[lang]["consent_modal"]["primary_btn"], // accept current selection
+                secondary_btn_data =
+                    user_config.languages[lang]["consent_modal"][
+                        "secondary_btn"
+                    ];
+
+            // Add primary button if not falsy
+            if (primary_btn_data) {
+                if (!consent_primary_btn) {
+                    consent_primary_btn = _createNode("button");
+                    consent_primary_btn.id = "c-p-bn";
+                    consent_primary_btn.className = "c-bn";
+
+                    var _accept_type;
+
+                    if (primary_btn_data["role"] === "accept_all")
+                        _accept_type = "all";
+
+                    _addEvent(consent_primary_btn, "click", function () {
+                        _cookieconsent.hide();
+                        _log(
+                            "CookieConsent [ACCEPT]: cookie_consent was accepted!"
+                        );
+                        _cookieconsent.accept(_accept_type);
+                    });
+                }
+
+                consent_primary_btn.innerHTML =
+                    user_config.languages[lang]["consent_modal"]["primary_btn"][
+                        "text"
+                    ];
+            }
+
+            // Add secondary button if not falsy
+            if (secondary_btn_data) {
+                if (!consent_secondary_btn) {
+                    consent_secondary_btn = _createNode("button");
+                    consent_secondary_btn.id = "c-s-bn";
+                    consent_secondary_btn.className = "c-bn c_link";
+
+                    if (secondary_btn_data["role"] === "accept_necessary") {
+                        _addEvent(consent_secondary_btn, "click", function () {
+                            _cookieconsent.hide();
+                            _cookieconsent.accept([]); // accept necessary only
+                        });
+                    } else {
+                        _addEvent(consent_secondary_btn, "click", function () {
+                            _cookieconsent.showSettings(0);
+                        });
+                    }
+                }
+
+                consent_secondary_btn.innerHTML =
+                    user_config.languages[lang]["consent_modal"][
+                        "secondary_btn"
+                    ]["text"];
+            }
+
+            // Swap buttons
+            var gui_options_data = user_config["gui_options"];
+
+            if (!consent_modal_inner) {
+                consent_modal_inner = _createNode("div");
+                consent_modal_inner.id = "c-inr";
+
+                consent_modal_inner.appendChild(consent_modal_inner_inner);
+            }
+
+            if (!consent_buttons) {
+                consent_buttons = _createNode("div");
+                consent_buttons.id = "c-bns";
+
+                if (
+                    gui_options_data &&
+                    gui_options_data["consent_modal"] &&
+                    gui_options_data["consent_modal"]["swap_buttons"] === true
+                ) {
+                    secondary_btn_data &&
+                        consent_buttons.appendChild(consent_secondary_btn);
+                    primary_btn_data &&
+                        consent_buttons.appendChild(consent_primary_btn);
+                    consent_buttons.className = "swap";
+                } else {
+                    primary_btn_data &&
+                        consent_buttons.appendChild(consent_primary_btn);
+                    secondary_btn_data &&
+                        consent_buttons.appendChild(consent_secondary_btn);
+                }
+
+                (primary_btn_data || secondary_btn_data) &&
+                    consent_modal_inner.appendChild(consent_buttons);
+                consent_modal.appendChild(consent_modal_inner);
+            }
+
+            // add links to privacy policy and imprint to modal
+            consent_links = _createNode("div");
+            consent_links.id = "c-link";
+
+            imprint_link =
+                user_config.languages[lang]["consent_modal"]["imprint_link"];
+            if (imprint_link) {
+                consent_links_imprint = _createNode("a");
+                consent_links_imprint.classList.add("cc-link");
+                consent_links_imprint.textContent = imprint_link["text"];
+                consent_links_imprint.setAttribute("href", imprint_link["url"]);
+                consent_links.appendChild(consent_links_imprint);
+            }
+
+            privacy_policy_link =
+                user_config.languages[lang]["consent_modal"][
+                    "privacy_policy_link"
+                ];
+            if (privacy_policy_link) {
+                consent_links_privacy = _createNode("a");
+                consent_links_privacy.classList.add("cc-link");
+                consent_links_privacy.textContent = privacy_policy_link["text"];
+                consent_links_privacy.setAttribute(
+                    "href",
+                    privacy_policy_link["url"]
+                );
+                consent_links.appendChild(consent_links_privacy);
+            }
+
+            consent_modal_inner.appendChild(consent_links);
+
+            consent_modal_exists = true;
+        };
+
+        var _createSettingsModal = function (lang) {
+            /**
+             * Create all consent_modal elements
+             */
+            if (!settings_container) {
+                settings_container = _createNode("div");
+                var settings_container_valign = _createNode("div");
+                var settings = _createNode("div");
+                var settings_container_inner = _createNode("div");
+                settings_inner = _createNode("div");
+                settings_title = _createNode("div");
+                var settings_header = _createNode("div");
+                settings_close_btn = _createNode("button");
+                var settings_close_btn_container = _createNode("div");
+                settings_blocks = _createNode("div");
+                var overlay = _createNode("div");
+
+                /**
+                 * Set ids
+                 */
+                settings_container.id = "s-cnt";
+                settings_container_valign.id = "c-vln";
+                settings_container_inner.id = "c-s-in";
+                settings.id = "cs";
+                settings_title.id = "s-ttl";
+                settings_inner.id = "s-inr";
+                settings_header.id = "s-hdr";
+                settings_blocks.id = "s-bl";
+                settings_close_btn.id = "s-c-bn";
+                overlay.id = "cs-ov";
+                settings_close_btn_container.id = "s-c-bnc";
+                settings_close_btn.className = "c-bn";
+
+                settings_container.setAttribute("role", "dialog");
+                settings_container.setAttribute("aria-modal", "true");
+                settings_container.setAttribute("aria-hidden", "true");
+                settings_container.setAttribute("aria-labelledby", "s-ttl");
+                settings_title.setAttribute("role", "heading");
+                settings_container.style.visibility = overlay.style.visibility =
+                    "hidden";
+                overlay.style.opacity = 0;
+
+                settings_close_btn_container.appendChild(settings_close_btn);
+
+                // If 'esc' key is pressed inside settings_container div => hide settings
+                _addEvent(
+                    settings_container_valign,
+                    "keydown",
+                    function (evt) {
+                        evt = evt || window.event;
+                        if (evt.keyCode === 27) {
+                            _cookieconsent.hideSettings(0);
+                        }
+                    },
+                    true
+                );
+
+                _addEvent(settings_close_btn, "click", function () {
+                    _cookieconsent.hideSettings(0);
+                });
+            } else {
+                new_settings_blocks = _createNode("div");
+                new_settings_blocks.id = "s-bl";
+            }
+
+            // Add label to close button
+            settings_close_btn.setAttribute(
+                "aria-label",
+                user_config.languages[lang]["settings_modal"][
+                    "close_btn_label"
+                ] || "Close"
+            );
+
+            all_blocks =
+                user_config.languages[lang]["settings_modal"]["blocks"];
+            all_table_headers =
+                user_config.languages[lang]["settings_modal"][
+                    "cookie_table_headers"
+                ];
+
+            var n_blocks = all_blocks.length;
+
+            // Set settings modal title
+            settings_title.innerHTML =
+                user_config.languages[lang]["settings_modal"]["title"];
+
+            // Create settings modal content (blocks)
+            for (var i = 0; i < n_blocks; ++i) {
+                var title_data = all_blocks[i]["title"],
+                    description_data = all_blocks[i]["description"],
+                    toggle_data = all_blocks[i]["toggle"],
+                    cookie_table_data = all_blocks[i]["cookie_table"],
+                    remove_cookie_tables =
+                        user_config["remove_cookie_tables"] === true,
+                    isExpandable =
+                        (description_data && "truthy") ||
+                        (!remove_cookie_tables &&
+                            cookie_table_data &&
+                            "truthy");
+
+                // Create title
+                var block_section = _createNode("div");
+                var block_table_container = _createNode("div");
+
+                // Create description
+                if (description_data) {
+                    var block_desc = _createNode("div");
+                    block_desc.className = "p";
+                    block_desc.insertAdjacentHTML(
+                        "beforeend",
+                        description_data
+                    );
+                }
+
+                var block_title_container = _createNode("div");
+                block_title_container.className = "title";
+
+                block_section.className = "c-bl";
+                block_table_container.className = "desc";
+
+                // Create toggle if specified (opt in/out)
+                if (typeof toggle_data !== "undefined") {
+                    var accordion_id = "c-ac-" + i;
+
+                    // Create button (to collapse/expand block description)
+                    var block_title_btn = isExpandable
+                        ? _createNode("button")
+                        : _createNode("div");
+                    var block_switch_label = _createNode("label");
+                    var block_switch = _createNode("input");
+                    var block_switch_span = _createNode("span");
+                    var label_text_span = _createNode("span");
+
+                    // These 2 spans will contain each 2 pseudo-elements to generate 'tick' and 'x' icons
+                    var block_switch_span_on_icon = _createNode("span");
+                    var block_switch_span_off_icon = _createNode("span");
+
+                    block_title_btn.className = isExpandable
+                        ? "b-tl exp"
+                        : "b-tl";
+                    block_switch_label.className = "b-tg";
+                    block_switch.className = "c-tgl";
+                    block_switch_span_on_icon.className = "on-i";
+                    block_switch_span_off_icon.className = "off-i";
+                    block_switch_span.className = "c-tg";
+                    label_text_span.className = "t-lb";
+
+                    if (isExpandable) {
+                        block_title_btn.setAttribute("aria-expanded", "false");
+                        block_title_btn.setAttribute(
+                            "aria-controls",
+                            accordion_id
+                        );
+                    }
+
+                    block_switch.type = "checkbox";
+                    block_switch_span.setAttribute("aria-hidden", "true");
+
+                    var cookie_category = toggle_data.value;
+                    block_switch.value = cookie_category;
+
+                    label_text_span.textContent = title_data;
+                    block_title_btn.insertAdjacentHTML("beforeend", title_data);
+
+                    block_title_container.appendChild(block_title_btn);
+                    block_switch_span.appendChild(block_switch_span_on_icon);
+                    block_switch_span.appendChild(block_switch_span_off_icon);
+
+                    /**
+                     * If consent is valid => retrieve category states from cookie
+                     * Otherwise use states defined in the user_config. object
+                     */
+                    if (!invalid_consent) {
+                        if (
+                            _inArray(
+                                saved_cookie_content["categories"],
+                                cookie_category
+                            ) > -1
+                        ) {
+                            block_switch.checked = true;
+                            !new_settings_blocks && toggle_states.push(true);
+                        } else {
+                            !new_settings_blocks && toggle_states.push(false);
+                        }
+                    } else if (toggle_data["enabled"]) {
+                        block_switch.checked = true;
+                        !new_settings_blocks && toggle_states.push(true);
+
+                        /**
+                         * Keep track of categories enabled by default (useful when mode=='opt-out')
+                         */
+                        if (toggle_data["enabled"])
+                            !new_settings_blocks &&
+                                default_enabled_categories.push(
+                                    cookie_category
+                                );
+                    } else {
+                        !new_settings_blocks && toggle_states.push(false);
+                    }
+
+                    !new_settings_blocks &&
+                        all_categories.push(cookie_category);
+
+                    /**
+                     * Set toggle as readonly if true (disable checkbox)
+                     */
+                    if (toggle_data["readonly"]) {
+                        block_switch.disabled = true;
+                        _addClass(block_switch_span, "c-ro");
+                        !new_settings_blocks && readonly_categories.push(true);
+                    } else {
+                        !new_settings_blocks && readonly_categories.push(false);
+                    }
+
+                    _addClass(block_table_container, "b-acc");
+                    _addClass(block_title_container, "b-bn");
+                    _addClass(block_section, "b-ex");
+
+                    block_table_container.id = accordion_id;
+                    block_table_container.setAttribute("aria-hidden", "true");
+
+                    block_switch_label.appendChild(block_switch);
+                    block_switch_label.appendChild(block_switch_span);
+                    block_switch_label.appendChild(label_text_span);
+                    block_title_container.appendChild(block_switch_label);
+
+                    /**
+                     * On button click handle the following :=> aria-expanded, aria-hidden and act class for current block
+                     */
+                    isExpandable &&
+                        (function (accordion, block_section, btn) {
+                            _addEvent(
+                                block_title_btn,
+                                "click",
+                                function () {
+                                    if (!_hasClass(block_section, "act")) {
+                                        _addClass(block_section, "act");
+                                        btn.setAttribute(
+                                            "aria-expanded",
+                                            "true"
+                                        );
+                                        accordion.setAttribute(
+                                            "aria-hidden",
+                                            "false"
+                                        );
+                                    } else {
+                                        _removeClass(block_section, "act");
+                                        btn.setAttribute(
+                                            "aria-expanded",
+                                            "false"
+                                        );
+                                        accordion.setAttribute(
+                                            "aria-hidden",
+                                            "true"
+                                        );
+                                    }
+                                },
+                                false
+                            );
+                        })(
+                            block_table_container,
+                            block_section,
+                            block_title_btn
+                        );
+                } else {
+                    /**
+                     * If block is not a button (no toggle defined),
+                     * create a simple div instead
+                     */
+                    if (title_data) {
+                        var block_title = _createNode("div");
+                        block_title.className = "b-tl";
+                        block_title.setAttribute("role", "heading");
+                        block_title.setAttribute("aria-level", "3");
+                        block_title.insertAdjacentHTML("beforeend", title_data);
+                        block_title_container.appendChild(block_title);
+                    }
+                }
+
+                title_data && block_section.appendChild(block_title_container);
+                description_data &&
+                    block_table_container.appendChild(block_desc);
+
+                // if cookie table found, generate table for this block
+                if (
+                    !remove_cookie_tables &&
+                    typeof cookie_table_data !== "undefined"
+                ) {
+                    var tr_tmp_fragment = document.createDocumentFragment();
+
+                    /**
+                     * Use custom table headers
+                     */
+                    for (var p = 0; p < all_table_headers.length; ++p) {
+                        // create new header
+                        var th1 = _createNode("th");
+                        var obj = all_table_headers[p];
+                        th1.setAttribute("scope", "col");
+
+                        // get custom header content
+                        if (obj) {
+                            var new_column_key = obj && _getKeys(obj)[0];
+                            th1.textContent =
+                                all_table_headers[p][new_column_key];
+                            tr_tmp_fragment.appendChild(th1);
+                        }
+                    }
+
+                    var tr_tmp = _createNode("tr");
+                    tr_tmp.appendChild(tr_tmp_fragment);
+
+                    // create table header & append fragment
+                    var thead = _createNode("thead");
+                    thead.appendChild(tr_tmp);
+
+                    // append header to table
+                    var block_table = _createNode("table");
+                    block_table.appendChild(thead);
+
+                    var tbody_fragment = document.createDocumentFragment();
+
+                    // create table content
+                    for (var n = 0; n < cookie_table_data.length; n++) {
+                        var tr = _createNode("tr");
+
+                        for (var g = 0; g < all_table_headers.length; ++g) {
+                            // get custom header content
+                            obj = all_table_headers[g];
+                            if (obj) {
+                                new_column_key = _getKeys(obj)[0];
+
+                                var td_tmp = _createNode("td");
+
+                                // Allow html inside table cells
+                                td_tmp.insertAdjacentHTML(
+                                    "beforeend",
+                                    cookie_table_data[n][new_column_key]
+                                );
+                                td_tmp.setAttribute(
+                                    "data-column",
+                                    obj[new_column_key]
+                                );
+
+                                tr.appendChild(td_tmp);
+                            }
+                        }
+
+                        tbody_fragment.appendChild(tr);
+                    }
+
+                    // append tbody_fragment to tbody & append the latter into the table
+                    var tbody = _createNode("tbody");
+                    tbody.appendChild(tbody_fragment);
+                    block_table.appendChild(tbody);
+
+                    block_table_container.appendChild(block_table);
+                }
+
+                /**
+                 * Append only if is either:
+                 * - togglable div with title
+                 * - a simple div with at least a title or description
+                 */
+                if (
+                    (toggle_data && title_data) ||
+                    (!toggle_data && (title_data || description_data))
+                ) {
+                    block_section.appendChild(block_table_container);
+
+                    if (new_settings_blocks)
+                        new_settings_blocks.appendChild(block_section);
+                    else settings_blocks.appendChild(block_section);
+                }
+            }
+
+            // Create settings buttons
+            if (!settings_buttons) {
+                settings_buttons = _createNode("div");
+                settings_buttons.id = "s-bns";
+            }
+
+            if (!settings_accept_all_btn) {
+                settings_accept_all_btn = _createNode("button");
+                settings_accept_all_btn.id = "s-all-bn";
+                settings_accept_all_btn.className = "c-bn";
+                settings_buttons.appendChild(settings_accept_all_btn);
+
+                _addEvent(settings_accept_all_btn, "click", function () {
+                    _cookieconsent.hideSettings();
+                    _cookieconsent.hide();
+                    _cookieconsent.accept("all");
+                });
+            }
+
+            settings_accept_all_btn.innerHTML =
+                user_config.languages[lang]["settings_modal"]["accept_all_btn"];
+
+            var reject_all_btn_text =
+                user_config.languages[lang]["settings_modal"]["reject_all_btn"];
+
+            // Add third [optional] reject all button if provided
+            if (reject_all_btn_text) {
+                if (!settings_reject_all_btn) {
+                    settings_reject_all_btn = _createNode("button");
+                    settings_reject_all_btn.id = "s-rall-bn";
+                    settings_reject_all_btn.className = "c-bn";
+
+                    _addEvent(settings_reject_all_btn, "click", function () {
+                        _cookieconsent.hideSettings();
+                        _cookieconsent.hide();
+                        _cookieconsent.accept([]);
+                    });
+
+                    settings_inner.className = "bns-t";
+                    settings_buttons.appendChild(settings_reject_all_btn);
+                }
+
+                settings_reject_all_btn.innerHTML = reject_all_btn_text;
+            }
+
+            if (!settings_save_btn) {
+                settings_save_btn = _createNode("button");
+                settings_save_btn.id = "s-sv-bn";
+                settings_save_btn.className = "c-bn";
+                settings_buttons.appendChild(settings_save_btn);
+
+                // Add save preferences button onClick event
+                // Hide both settings modal and consent modal
+                _addEvent(settings_save_btn, "click", function () {
+                    _cookieconsent.hideSettings();
+                    _cookieconsent.hide();
+                    _cookieconsent.accept();
+                });
+            }
+
+            settings_save_btn.innerHTML =
+                user_config.languages[lang]["settings_modal"][
+                    "save_settings_btn"
+                ];
+
+            if (new_settings_blocks) {
+                // replace entire existing cookie category blocks with the new cookie categories new blocks (in a different language)
+                settings_inner.replaceChild(
+                    new_settings_blocks,
+                    settings_blocks
+                );
+                settings_blocks = new_settings_blocks;
+                return;
+            }
+
+            settings_header.appendChild(settings_title);
+            settings_header.appendChild(settings_close_btn_container);
+            settings_inner.appendChild(settings_header);
+            settings_inner.appendChild(settings_blocks);
+            settings_inner.appendChild(settings_buttons);
+            settings_container_inner.appendChild(settings_inner);
+
+            settings.appendChild(settings_container_inner);
+            settings_container_valign.appendChild(settings);
+            settings_container.appendChild(settings_container_valign);
+
+            all_modals_container.appendChild(settings_container);
+            all_modals_container.appendChild(overlay);
+        };
+
+        /**
+         * Generate cookie consent html markup
+         */
+        var _createCookieConsentHTML = function () {
+            // Create main container which holds both consent modal & settings modal
+            main_container = _createNode("div");
+            main_container.id = "cc--main";
+
+            // Fix layout flash
+            main_container.style.position = "fixed";
+            main_container.style.zIndex = "1000000";
+            main_container.innerHTML =
+                '<!--[if lt IE 9 ]><div id="cc_div" class="cc_div ie"></div><![endif]--><!--[if (gt IE 8)|!(IE)]><!--><div id="cc_div" class="cc_div"></div><!--<![endif]-->';
+            all_modals_container = main_container.children[0];
+
+            // Get current language
+            var lang = _config.current_lang;
+
+            // Create consent modal
+            if (consent_modal_exists) _createConsentModal(lang);
+
+            // Always create settings modal
+            _createSettingsModal(lang);
+
+            // Finally append everything (main_container holds both modals)
+            (root || document.body).appendChild(main_container);
+        };
+
+        /**
+         * Update/change modals language
+         * @param {String} lang new language
+         * @param {Boolean} [force] update language fields forcefully
+         * @returns {Boolean}
+         */
+        _cookieconsent.updateLanguage = function (lang, force) {
+            if (typeof lang !== "string") return;
+
+            /**
+             * Validate language to avoid errors
+             */
+            var new_validated_lang = _getValidatedLanguage(
+                lang,
+                user_config.languages
+            );
+
+            /**
+             * Set language only if it differs from current
+             */
+            if (new_validated_lang !== _config.current_lang || force === true) {
+                _config.current_lang = new_validated_lang;
+
+                if (consent_modal_exists) {
+                    _createConsentModal(new_validated_lang);
+                    _addDataButtonListeners(consent_modal_inner);
+                }
+
+                _createSettingsModal(new_validated_lang);
+
+                _log(
+                    "CookieConsent [LANGUAGE]: curr_lang: '" +
+                        new_validated_lang +
+                        "'"
+                );
+
+                return true;
+            }
+
+            return false;
+        };
+
+        /**
+         * Delete all cookies which are unused (based on selected preferences)
+         *
+         * @param {boolean} [clearOnFirstAction]
+         */
+        var _autoclearCookies = function (clearOnFirstAction) {
+            // Get number of blocks
+            var len = all_blocks.length;
+            var count = -1;
+
+            // reset reload state
+            reload_page = false;
+
+            // Retrieve all cookies
+            var all_cookies_array = _getCookie("", "all");
+
+            // delete cookies on 'www.domain.com' and '.www.domain.com' (can also be without www)
+            var domains = [_config.cookie_domain, "." + _config.cookie_domain];
+
+            // if domain has www, delete cookies also for 'domain.com' and '.domain.com'
+            if (_config.cookie_domain.slice(0, 4) === "www.") {
+                var non_www_domain = _config.cookie_domain.substr(4); // remove first 4 chars (www.)
+                domains.push(non_www_domain);
+                domains.push("." + non_www_domain);
+            }
+
+            // For each block
+            for (var i = 0; i < len; i++) {
+                // Save current block (local scope & less accesses -> ~faster value retrieval)
+                var curr_block = all_blocks[i];
+
+                // If current block has a toggle for opt in/out
+                if (
+                    Object.prototype.hasOwnProperty.call(curr_block, "toggle")
+                ) {
+                    // if current block has a cookie table, an off toggle,
+                    // and its preferences were just changed => delete cookies
+                    var category_just_disabled =
+                        _inArray(
+                            changed_settings,
+                            curr_block["toggle"]["value"]
+                        ) > -1;
+                    if (
+                        !toggle_states[++count] &&
+                        Object.prototype.hasOwnProperty.call(
+                            curr_block,
+                            "cookie_table"
+                        ) &&
+                        (clearOnFirstAction || category_just_disabled)
+                    ) {
+                        var curr_cookie_table = curr_block["cookie_table"];
+
+                        // Get first property name
+                        var ckey = _getKeys(all_table_headers[0])[0];
+
+                        // Get number of cookies defined in cookie_table
+                        var clen = curr_cookie_table.length;
+
+                        // set "reload_page" to true if reload=on_disable
+                        if (curr_block["toggle"]["reload"] === "on_disable")
+                            category_just_disabled && (reload_page = true);
+
+                        // for each row defined in the cookie table
+                        for (var j = 0; j < clen; j++) {
+                            // Get current row of table (corresponds to all cookie params)
+                            var curr_row = curr_cookie_table[j],
+                                found_cookies = [];
+                            var curr_cookie_name = curr_row[ckey];
+                            var is_regex = curr_row["is_regex"] || false;
+                            var curr_cookie_domain = curr_row["domain"] || null;
+                            var curr_cookie_path = curr_row["path"] || false;
+
+                            // set domain to the specified domain
+                            curr_cookie_domain &&
+                                (domains = [
+                                    curr_cookie_domain,
+                                    "." + curr_cookie_domain,
+                                ]);
+
+                            // If regex provided => filter cookie array
+                            if (is_regex) {
+                                for (
+                                    var n = 0;
+                                    n < all_cookies_array.length;
+                                    n++
+                                ) {
+                                    if (
+                                        all_cookies_array[n].match(
+                                            curr_cookie_name
+                                        )
+                                    ) {
+                                        found_cookies.push(
+                                            all_cookies_array[n]
+                                        );
+                                    }
+                                }
+                            } else {
+                                var found_index = _inArray(
+                                    all_cookies_array,
+                                    curr_cookie_name
+                                );
+                                if (found_index > -1)
+                                    found_cookies.push(
+                                        all_cookies_array[found_index]
+                                    );
+                            }
+
+                            _log(
+                                "CookieConsent [AUTOCLEAR]: search cookie: '" +
+                                    curr_cookie_name +
+                                    "', found:",
+                                found_cookies
+                            );
+
+                            // If cookie exists -> delete it
+                            if (found_cookies.length > 0) {
+                                _eraseCookies(
+                                    found_cookies,
+                                    curr_cookie_path,
+                                    domains
+                                );
+                                curr_block["toggle"]["reload"] === "on_clear" &&
+                                    (reload_page = true);
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        /**
+         * Set toggles/checkboxes based on accepted categories and save cookie
+         * @param {string[]} accepted_categories - Array of categories to accept
+         */
+        var _saveCookiePreferences = function (accepted_categories) {
+            changed_settings = [];
+
+            // Retrieve all toggle/checkbox values
+            var category_toggles = document.querySelectorAll(".c-tgl") || [];
+
+            // If there are opt in/out toggles ...
+            if (category_toggles.length > 0) {
+                for (var i = 0; i < category_toggles.length; i++) {
+                    if (
+                        _inArray(accepted_categories, all_categories[i]) !== -1
+                    ) {
+                        category_toggles[i].checked = true;
+                        if (!toggle_states[i]) {
+                            changed_settings.push(all_categories[i]);
+                            toggle_states[i] = true;
+                        }
+                    } else {
+                        category_toggles[i].checked = false;
+                        if (toggle_states[i]) {
+                            changed_settings.push(all_categories[i]);
+                            toggle_states[i] = false;
+                        }
+                    }
+                }
+            }
+
+            /**
+             * Clear cookies when settings/preferences change
+             */
+            if (
+                !invalid_consent &&
+                _config.autoclear_cookies &&
+                changed_settings.length > 0
+            )
+                _autoclearCookies();
+
+            if (!consent_date) consent_date = new Date();
+            if (!consent_uuid) consent_uuid = _uuidv4();
+
+            saved_cookie_content = {
+                categories: accepted_categories,
+                revision: _config.revision,
+                data: cookie_data,
+                rfc_cookie: _config.use_rfc_cookie,
+                consent_date: consent_date.toISOString(),
+                consent_uuid: consent_uuid,
+            };
+
+            // save cookie with preferences 'categories' (only if never accepted or settings were updated)
+            if (invalid_consent || changed_settings.length > 0) {
+                valid_revision = true;
+
+                /**
+                 * Update "last_consent_update" only if it is invalid (after t)
+                 */
+                if (!last_consent_update) last_consent_update = consent_date;
+                else last_consent_update = new Date();
+
+                saved_cookie_content["last_consent_update"] =
+                    last_consent_update.toISOString();
+
+                /**
+                 * Update accept type
+                 */
+                accept_type = _getAcceptType(_getCurrentCategoriesState());
+
+                _setCookie(
+                    _config.cookie_name,
+                    JSON.stringify(saved_cookie_content)
+                );
+                _manageExistingScripts();
+
+                //_printConsentDateHTML();
+            }
+
+            if (invalid_consent) {
+                /**
+                 * Delete unused/"zombie" cookies if consent is not valid (not yet expressed or cookie has expired)
+                 */
+                if (_config.autoclear_cookies) _autoclearCookies(true);
+
+                if (typeof onFirstAction === "function")
+                    onFirstAction(
+                        _cookieconsent.getUserPreferences(),
+                        saved_cookie_content
+                    );
+
+                if (typeof onAccept === "function")
+                    onAccept(saved_cookie_content);
+
+                /**
+                 * Set consent as valid
+                 */
+                invalid_consent = false;
+
+                if (_config.mode === "opt-in") return;
+            }
+
+            // fire onChange only if settings were changed
+            if (typeof onChange === "function" && changed_settings.length > 0)
+                onChange(saved_cookie_content, changed_settings);
+
+            /**
+             * reload page if needed
+             */
+            if (reload_page) window.location.reload();
+        };
+
+        /**
+         * Returns index of found element inside array, otherwise -1
+         * @param {Array} arr
+         * @param {Object} value
+         * @returns {number}
+         */
+        var _inArray = function (arr, value) {
+            return arr.indexOf(value);
+        };
+
+        /**
+         * Helper function which prints info (console.log())
+         * @param {Object} print_msg
+         * @param {Object} [optional_param]
+         */
+        var _log = function (print_msg, optional_param, error) {
+            ENABLE_LOGS &&
+                (!error
+                    ? console.log(
+                          print_msg,
+                          optional_param !== undefined ? optional_param : " "
+                      )
+                    : console.error(print_msg, optional_param || ""));
+        };
+
+        /**
+         * Helper function which creates an HTMLElement object based on 'type' and returns it.
+         * @param {string} type
+         * @returns {HTMLElement}
+         */
+        var _createNode = function (type) {
+            var el = document.createElement(type);
+            if (type === "button") {
+                el.setAttribute("type", type);
+            }
+            return el;
+        };
+
+        /**
+         * Generate RFC4122-compliant UUIDs.
+         * https://stackoverflow.com/questions/105034/how-to-create-a-guid-uuid?page=1&tab=votes#tab-top
+         * @returns {string}
+         */
+        var _uuidv4 = function () {
+            return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(
+                /[018]/g,
+                function (c) {
+                    return (
+                        c ^
+                        ((window.crypto || window.msCrypto).getRandomValues(
+                            new Uint8Array(1)
+                        )[0] &
+                            (15 >> (c / 4)))
+                    ).toString(16);
+                }
+            );
+        };
+
+        /**
+         * Resolve which language should be used.
+         *
+         * @param {Object} languages Object with language translations
+         * @param {string} [requested_language] Language specified by given configuration parameters
+         * @returns {string}
+         */
+        var _resolveCurrentLang = function (languages, requested_language) {
+            if (_config.auto_language === "browser") {
+                return _getValidatedLanguage(_getBrowserLang(), languages);
+            } else if (_config.auto_language === "document") {
+                return _getValidatedLanguage(
+                    document.documentElement.lang,
+                    languages
+                );
+            } else {
+                if (typeof requested_language === "string") {
+                    return (_config.current_lang = _getValidatedLanguage(
+                        requested_language,
+                        languages
+                    ));
+                }
+            }
+
+            _log(
+                "CookieConsent [LANG]: setting current_lang = '" +
+                    _config.current_lang +
+                    "'"
+            );
+            return _config.current_lang; // otherwise return default
+        };
+
+        /**
+         * Get current client's browser language
+         * @returns {string}
+         */
+        var _getBrowserLang = function () {
+            var browser_lang = navigator.language || navigator.browserLanguage;
+            browser_lang.length > 2 &&
+                (browser_lang = browser_lang[0] + browser_lang[1]);
+            _log(
+                "CookieConsent [LANG]: detected_browser_lang = '" +
+                    browser_lang +
+                    "'"
+            );
+            return browser_lang.toLowerCase();
+        };
+
+        /**
+         * Trap focus inside modal and focus the first
+         * focusable element of current active modal
+         */
+        var _handleFocusTrap = function () {
+            var tabbedOutsideDiv = false;
+            var tabbedInsideModal = false;
+
+            _addEvent(document, "keydown", function (e) {
+                e = e || window.event;
+
+                // If is tab key => ok
+                if (e.key !== "Tab") return;
+
+                // If there is any modal to focus
+                if (current_modal_focusable) {
+                    // If reached natural end of the tab sequence => restart
+                    if (e.shiftKey) {
+                        if (
+                            document.activeElement ===
+                            current_modal_focusable[0]
+                        ) {
+                            current_modal_focusable[1].focus();
+                            e.preventDefault();
+                        }
+                    } else {
+                        if (
+                            document.activeElement ===
+                            current_modal_focusable[1]
+                        ) {
+                            current_modal_focusable[0].focus();
+                            e.preventDefault();
+                        }
+                    }
+
+                    // If have not yet used tab (or shift+tab) and modal is open ...
+                    // Focus the first focusable element
+                    if (!tabbedInsideModal && !clicked_inside_modal) {
+                        tabbedInsideModal = true;
+                        !tabbedOutsideDiv && e.preventDefault();
+
+                        if (e.shiftKey) {
+                            if (current_modal_focusable[3]) {
+                                if (!current_modal_focusable[2]) {
+                                    current_modal_focusable[0].focus();
+                                } else {
+                                    current_modal_focusable[2].focus();
+                                }
+                            } else {
+                                current_modal_focusable[1].focus();
+                            }
+                        } else {
+                            if (current_modal_focusable[3]) {
+                                current_modal_focusable[3].focus();
+                            } else {
+                                current_modal_focusable[0].focus();
+                            }
+                        }
+                    }
+                }
+
+                !tabbedInsideModal && (tabbedOutsideDiv = true);
+            });
+
+            if (document.contains) {
+                _addEvent(
+                    main_container,
+                    "click",
+                    function (e) {
+                        e = e || window.event;
+                        /**
+                         * If click is on the foreground overlay (and not inside settings_modal),
+                         * hide settings modal
+                         *
+                         * Notice: click on div is not supported in IE
+                         */
+                        if (settings_modal_visible) {
+                            if (!settings_inner.contains(e.target)) {
+                                _cookieconsent.hideSettings(0);
+                                clicked_inside_modal = false;
+                            } else {
+                                clicked_inside_modal = true;
+                            }
+                        } else if (consent_modal_visible) {
+                            if (consent_modal.contains(e.target)) {
+                                clicked_inside_modal = true;
+                            }
+                        }
+                    },
+                    true
+                );
+            }
+        };
+
+        /**
+         * Manage each modal's layout
+         * @param {Object} gui_options
+         */
+        var _guiManager = function (gui_options, only_consent_modal) {
+            // If gui_options is not object => exit
+            if (typeof gui_options !== "object") return;
+
+            var consent_modal_options = gui_options["consent_modal"];
+            var settings_modal_options = gui_options["settings_modal"];
+
+            /**
+             * Helper function which adds layout and
+             * position classes to given modal
+             *
+             * @param {HTMLElement} modal
+             * @param {string[]} allowed_layouts
+             * @param {string[]} allowed_positions
+             * @param {string} layout
+             * @param {string[]} position
+             */
+            function _setLayout(
+                modal,
+                allowed_layouts,
+                allowed_positions,
+                allowed_transitions,
+                layout,
+                position,
+                transition
+            ) {
+                position = (position && position.split(" ")) || [];
+
+                // Check if specified layout is valid
+                if (_inArray(allowed_layouts, layout) > -1) {
+                    // Add layout classes
+                    _addClass(modal, layout);
+
+                    // Add position class (if specified)
+                    if (
+                        !(layout === "bar" && position[0] === "middle") &&
+                        _inArray(allowed_positions, position[0]) > -1
+                    ) {
+                        for (var i = 0; i < position.length; i++) {
+                            _addClass(modal, position[i]);
+                        }
+                    }
+                }
+
+                // Add transition class
+                _inArray(allowed_transitions, transition) > -1 &&
+                    _addClass(modal, transition);
+            }
+
+            if (consent_modal_exists && consent_modal_options) {
+                _setLayout(
+                    consent_modal,
+                    ["box", "bar", "cloud"],
+                    ["top", "middle", "bottom"],
+                    ["zoom", "slide"],
+                    consent_modal_options["layout"],
+                    consent_modal_options["position"],
+                    consent_modal_options["transition"]
+                );
+            }
+
+            if (!only_consent_modal && settings_modal_options) {
+                _setLayout(
+                    settings_container,
+                    ["bar"],
+                    ["left", "right"],
+                    ["zoom", "slide"],
+                    settings_modal_options["layout"],
+                    settings_modal_options["position"],
+                    settings_modal_options["transition"]
+                );
+            }
+        };
+
+        /**
+         * Returns true if cookie category is accepted by the user
+         * @param {string} cookie_category
+         * @returns {boolean}
+         */
+        _cookieconsent.allowedCategory = function (cookie_category) {
+            if (!invalid_consent || _config.mode === "opt-in")
+                var allowed_categories =
+                    JSON.parse(
+                        _getCookie(_config.cookie_name, "one", true) || "{}"
+                    )["categories"] || [];
+            // mode is 'opt-out'
+            else var allowed_categories = default_enabled_categories;
+
+            return _inArray(allowed_categories, cookie_category) > -1;
+        };
+
+        /**
+         * "Init" method. Will run once and only if modals do not exist
+         */
+        _cookieconsent.run = function (user_config) {
+            if (!document.getElementById("cc_div")) {
+                // configure all parameters
+                _setConfig(user_config);
+
+                // if is bot, don't run plugin
+                if (is_bot) return;
+
+                // Retrieve cookie value (if set)
+                saved_cookie_content = JSON.parse(
+                    _getCookie(_config.cookie_name, "one", true) || "{}"
+                );
+
+                // Retrieve "consent_uuid"
+                consent_uuid = saved_cookie_content["consent_uuid"];
+
+                // If "consent_uuid" is present => assume that consent was previously given
+                var cookie_consent_accepted = consent_uuid !== undefined;
+
+                // Retrieve "consent_date"
+                consent_date = saved_cookie_content["consent_date"];
+                consent_date && (consent_date = new Date(consent_date));
+
+                // Retrieve "last_consent_update"
+                last_consent_update =
+                    saved_cookie_content["last_consent_update"];
+                last_consent_update &&
+                    (last_consent_update = new Date(last_consent_update));
+
+                // Retrieve "data"
+                cookie_data =
+                    saved_cookie_content["data"] !== undefined
+                        ? saved_cookie_content["data"]
+                        : null;
+
+                // If revision is enabled and current value !== saved value inside the cookie => revision is not valid
+                if (
+                    revision_enabled &&
+                    saved_cookie_content["revision"] !== _config.revision
+                ) {
+                    valid_revision = false;
+                }
+
+                // If consent is not valid => create consent modal
+                consent_modal_exists = invalid_consent =
+                    !cookie_consent_accepted ||
+                    !valid_revision ||
+                    !consent_date ||
+                    !last_consent_update ||
+                    !consent_uuid;
+
+                // Generate cookie-settings dom (& consent modal)
+                _createCookieConsentHTML();
+
+                _getModalFocusableData();
+                _guiManager(user_config["gui_options"]);
+                _addDataButtonListeners();
+
+                if (_config.autorun && consent_modal_exists) {
+                    _cookieconsent.show(user_config["delay"] || 0);
+                }
+
+                // Add class to enable animations/transitions
+                setTimeout(function () {
+                    _addClass(main_container, "c--anim");
+                }, 30);
+
+                // Accessibility :=> if tab pressed => trap focus inside modal
+                setTimeout(function () {
+                    _handleFocusTrap();
+                }, 100);
+
+                // If consent is valid
+                if (!invalid_consent) {
+                    var rfc_prop_exists =
+                        typeof saved_cookie_content["rfc_cookie"] === "boolean";
+
+                    /*
+                     * Convert cookie to rfc format (if `use_rfc_cookie` is enabled)
+                     */
+                    if (
+                        !rfc_prop_exists ||
+                        (rfc_prop_exists &&
+                            saved_cookie_content["rfc_cookie"] !==
+                                _config.use_rfc_cookie)
+                    ) {
+                        saved_cookie_content["rfc_cookie"] =
+                            _config.use_rfc_cookie;
+                        _setCookie(
+                            _config.cookie_name,
+                            JSON.stringify(saved_cookie_content)
+                        );
+                    }
+
+                    /**
+                     * Update accept type
+                     */
+                    accept_type = _getAcceptType(_getCurrentCategoriesState());
+
+                    _manageExistingScripts();
+
+                    if (typeof onAccept === "function")
+                        onAccept(saved_cookie_content);
+
+                    _log(
+                        "CookieConsent [NOTICE]: consent already given!",
+                        saved_cookie_content
+                    );
+                } else {
+                    if (_config.mode === "opt-out") {
+                        _log(
+                            "CookieConsent [CONFIG] mode='" +
+                                _config.mode +
+                                "', default enabled categories:",
+                            default_enabled_categories
+                        );
+                        _manageExistingScripts(default_enabled_categories);
+                    }
+                    _log("CookieConsent [NOTICE]: ask for consent!");
+                }
+            } else {
+                _log(
+                    "CookieConsent [NOTICE]: cookie consent already attached to body!"
+                );
+            }
+        };
+
+        /**
+         * Show settings modal (with optional delay)
+         * @param {number} delay
+         */
+        _cookieconsent.showSettings = function (delay) {
+            setTimeout(
+                function () {
+                    _addClass(html_dom, "show--settings");
+                    settings_container.setAttribute("aria-hidden", "false");
+                    settings_modal_visible = true;
+
+                    /**
+                     * Set focus to the first focusable element inside settings modal
+                     */
+                    setTimeout(function () {
+                        // If there is no consent-modal, keep track of the last focused elem.
+                        if (!consent_modal_visible) {
+                            last_elem_before_modal = document.activeElement;
+                        } else {
+                            last_consent_modal_btn_focus =
+                                document.activeElement;
+                        }
+
+                        if (settings_modal_focusable.length === 0) return;
+
+                        if (settings_modal_focusable[3]) {
+                            settings_modal_focusable[3].focus();
+                        } else {
+                            settings_modal_focusable[0].focus();
+                        }
+                        current_modal_focusable = settings_modal_focusable;
+                    }, 200);
+
+                    _log("CookieConsent [SETTINGS]: show settings_modal");
+                },
+                delay > 0 ? delay : 0
+            );
+        };
+
+        /**
+         * This function handles the loading/activation logic of the already
+         * existing scripts based on the current accepted cookie categories
+         *
+         * @param {string[]} [must_enable_categories]
+         */
+        var _manageExistingScripts = function (must_enable_categories) {
+            if (!_config.page_scripts) return;
+
+            // get all the scripts with "cookie-category" attribute
+            var scripts = document.querySelectorAll(
+                "script[" + _config.script_selector + "]"
+            );
+            var accepted_categories =
+                must_enable_categories ||
+                saved_cookie_content["categories"] ||
+                [];
+
+            /**
+             * Load scripts (sequentially), using a recursive function
+             * which loops through the scripts array
+             * @param {Element[]} scripts scripts to load
+             * @param {number} index current script to load
+             */
+            var _loadScripts = function (scripts, index) {
+                if (index < scripts.length) {
+                    var curr_script = scripts[index];
+                    var curr_script_category = curr_script.getAttribute(
+                        _config.script_selector
+                    );
+
+                    /**
+                     * If current script's category is on the array of categories
+                     * accepted by the user => load script
+                     */
+                    if (
+                        _inArray(accepted_categories, curr_script_category) > -1
+                    ) {
+                        curr_script.type = "text/javascript";
+                        curr_script.removeAttribute(_config.script_selector);
+
+                        // get current script data-src
+                        var src = curr_script.getAttribute("data-src");
+
+                        // some scripts (like ga) might throw warning if data-src is present
+                        src && curr_script.removeAttribute("data-src");
+
+                        // create fresh script (with the same code)
+                        var fresh_script = _createNode("script");
+                        fresh_script.textContent = curr_script.innerHTML;
+
+                        // Copy attributes over to the new "revived" script
+                        (function (destination, source) {
+                            var attributes = source.attributes;
+                            var len = attributes.length;
+                            for (var i = 0; i < len; i++) {
+                                var attr_name = attributes[i].nodeName;
+                                destination.setAttribute(
+                                    attr_name,
+                                    source[attr_name] ||
+                                        source.getAttribute(attr_name)
+                                );
+                            }
+                        })(fresh_script, curr_script);
+
+                        // set src (if data-src found)
+                        src
+                            ? (fresh_script.src = src)
+                            : (src = curr_script.src);
+
+                        // if script has "src" attribute
+                        // try loading it sequentially
+                        if (src) {
+                            // load script sequentially => the next script will not be loaded
+                            // until the current's script onload event triggers
+                            if (fresh_script.readyState) {
+                                // only required for IE <9
+                                fresh_script.onreadystatechange = function () {
+                                    if (
+                                        fresh_script.readyState === "loaded" ||
+                                        fresh_script.readyState === "complete"
+                                    ) {
+                                        fresh_script.onreadystatechange = null;
+                                        _loadScripts(scripts, ++index);
+                                    }
+                                };
+                            } else {
+                                // others
+                                fresh_script.onload = function () {
+                                    fresh_script.onload = null;
+                                    _loadScripts(scripts, ++index);
+                                };
+                            }
+                        }
+
+                        // Replace current "sleeping" script with the new "revived" one
+                        curr_script.parentNode.replaceChild(
+                            fresh_script,
+                            curr_script
+                        );
+
+                        /**
+                         * If we managed to get here and scr is still set, it means that
+                         * the script is loading/loaded sequentially so don't go any further
+                         */
+                        if (src) return;
+                    }
+
+                    // Go to next script right away
+                    _loadScripts(scripts, ++index);
+                }
+            };
+
+            _loadScripts(scripts, 0);
+        };
+
+        /**
+         * Save custom data inside cookie
+         * @param {object|string} new_data
+         * @param {string} [mode]
+         * @returns {boolean}
+         */
+        var _setCookieData = function (new_data, mode) {
+            var set = false;
+            /**
+             * If mode is 'update':
+             * add/update only the specified props.
+             */
+            if (mode === "update") {
+                cookie_data = _cookieconsent.get("data");
+                var same_type = typeof cookie_data === typeof new_data;
+
+                if (same_type && typeof cookie_data === "object") {
+                    !cookie_data && (cookie_data = {});
+
+                    for (var prop in new_data) {
+                        if (cookie_data[prop] !== new_data[prop]) {
+                            cookie_data[prop] = new_data[prop];
+                            set = true;
+                        }
+                    }
+                } else if (
+                    (same_type || !cookie_data) &&
+                    cookie_data !== new_data
+                ) {
+                    cookie_data = new_data;
+                    set = true;
+                }
+            } else {
+                cookie_data = new_data;
+                set = true;
+            }
+
+            if (set) {
+                saved_cookie_content["data"] = cookie_data;
+                _setCookie(
+                    _config.cookie_name,
+                    JSON.stringify(saved_cookie_content)
+                );
+            }
+
+            return set;
+        };
+
+        /**
+         * Helper method to set a variety of fields
+         * @param {string} field
+         * @param {object} data
+         * @returns {boolean}
+         */
+        _cookieconsent.set = function (field, data) {
+            switch (field) {
+                case "data":
+                    return _setCookieData(data["value"], data["mode"]);
+                default:
+                    return false;
+            }
+        };
+
+        /**
+         * Retrieve data from existing cookie
+         * @param {string} field
+         * @param {string} [cookie_name]
+         * @returns {any}
+         */
+        _cookieconsent.get = function (field, cookie_name) {
+            var cookie = JSON.parse(
+                _getCookie(cookie_name || _config.cookie_name, "one", true) ||
+                    "{}"
+            );
+
+            return cookie[field];
+        };
+
+        /**
+         * Read current configuration value
+         * @returns {any}
+         */
+        _cookieconsent.getConfig = function (field) {
+            return _config[field] || user_config[field];
+        };
+
+        /**
+         * Obtain accepted and rejected categories
+         * @returns {{accepted: string[], rejected: string[]}}
+         */
+        var _getCurrentCategoriesState = function () {
+            // get accepted categories
+            accepted_categories = saved_cookie_content["categories"] || [];
+
+            // calculate rejected categories (all_categories - accepted_categories)
+            rejected_categories = all_categories.filter(function (category) {
+                return _inArray(accepted_categories, category) === -1;
+            });
+
+            return {
+                accepted: accepted_categories,
+                rejected: rejected_categories,
+            };
+        };
+
+        /**
+         * Calculate "accept type" given current categories state
+         * @param {{accepted: string[], rejected: string[]}} currentCategoriesState
+         * @returns {string}
+         */
+        var _getAcceptType = function (currentCategoriesState) {
+            var type = "custom";
+
+            // number of categories marked as necessary/readonly
+            var necessary_categories_length = readonly_categories.filter(
+                function (readonly) {
+                    return readonly === true;
+                }
+            ).length;
+
+            // calculate accept type based on accepted/rejected categories
+            if (
+                currentCategoriesState.accepted.length === all_categories.length
+            )
+                type = "all";
+            else if (
+                currentCategoriesState.accepted.length ===
+                necessary_categories_length
+            )
+                type = "necessary";
+
+            return type;
+        };
+
+        /**
+         * @typedef {object} userPreferences
+         * @property {string} accept_type
+         * @property {string[]} accepted_categories
+         * @property {string[]} rejected_categories
+         */
+
+        /**
+         * Retrieve current user preferences (summary)
+         * @returns {userPreferences}
+         */
+        _cookieconsent.getUserPreferences = function () {
+            var currentCategoriesState = _getCurrentCategoriesState();
+            var accept_type = _getAcceptType(currentCategoriesState);
+
+            return {
+                accept_type: accept_type,
+                accepted_categories: currentCategoriesState.accepted,
+                rejected_categories: currentCategoriesState.rejected,
+            };
+        };
+
+        /**
+         * Function which will run after script load
+         * @callback scriptLoaded
+         */
+
+        /**
+         * Dynamically load script (append to head)
+         * @param {string} src
+         * @param {scriptLoaded} callback
+         * @param {object[]} [attrs] Custom attributes
+         */
+        _cookieconsent.loadScript = function (src, callback, attrs) {
+            var function_defined = typeof callback === "function";
+
+            // Load script only if not already loaded
+            if (!document.querySelector('script[src="' + src + '"]')) {
+                var script = _createNode("script");
+
+                // if an array is provided => add custom attributes
+                if (attrs && attrs.length > 0) {
+                    for (var i = 0; i < attrs.length; ++i) {
+                        attrs[i] &&
+                            script.setAttribute(
+                                attrs[i]["name"],
+                                attrs[i]["value"]
+                            );
+                    }
+                }
+
+                // if callback function defined => run callback onload
+                if (function_defined) {
+                    script.onload = callback;
+                }
+
+                script.src = src;
+
+                /**
+                 * Append script to head
+                 */
+                document.head.appendChild(script);
+            } else {
+                function_defined && callback();
+            }
+        };
+
+        /**
+         * Manage dynamically loaded scripts: https://github.com/orestbida/cookieconsent/issues/101
+         * If plugin has already run, call this method to enable
+         * the newly added scripts based on currently selected preferences
+         */
+        _cookieconsent.updateScripts = function () {
+            _manageExistingScripts();
+        };
+
+        /**
+         * Show cookie consent modal (with delay parameter)
+         * @param {number} [delay]
+         * @param {boolean} [create_modal] create modal if it doesn't exist
+         */
+        _cookieconsent.show = function (delay, create_modal) {
+            if (create_modal === true)
+                _createConsentModal(_config.current_lang);
+
+            if (consent_modal_exists) {
+                setTimeout(
+                    function () {
+                        _addClass(html_dom, "show--consent");
+
+                        /**
+                         * Update attributes/internal statuses
+                         */
+                        consent_modal.setAttribute("aria-hidden", "false");
+                        consent_modal_visible = true;
+
+                        setTimeout(function () {
+                            last_elem_before_modal = document.activeElement;
+                            current_modal_focusable = consent_modal_focusable;
+                        }, 200);
+
+                        _log("CookieConsent [MODAL]: show consent_modal");
+                    },
+                    delay > 0 ? delay : create_modal ? 30 : 0
+                );
+            }
+        };
+
+        /**
+         * Hide consent modal
+         */
+        _cookieconsent.hide = function () {
+            if (consent_modal_exists) {
+                _removeClass(html_dom, "show--consent");
+                consent_modal.setAttribute("aria-hidden", "true");
+                consent_modal_visible = false;
+
+                setTimeout(function () {
+                    //restore focus to the last page element which had focus before modal opening
+                    last_elem_before_modal.focus();
+                    current_modal_focusable = null;
+                }, 200);
+
+                _log("CookieConsent [MODAL]: hide");
+            }
+        };
+
+        /**
+         * Hide settings modal
+         */
+        _cookieconsent.hideSettings = function () {
+            _removeClass(html_dom, "show--settings");
+            settings_modal_visible = false;
+            settings_container.setAttribute("aria-hidden", "true");
 
             setTimeout(function () {
-              last_elem_before_modal = document.activeElement;
-              current_modal_focusable = consent_modal_focusable;
+                /**
+                 * If consent modal is visible, focus him (instead of page document)
+                 */
+                if (consent_modal_visible) {
+                    last_consent_modal_btn_focus &&
+                        last_consent_modal_btn_focus.focus();
+                    current_modal_focusable = consent_modal_focusable;
+                } else {
+                    /**
+                     * Restore focus to last page element which had focus before modal opening
+                     */
+                    last_elem_before_modal && last_elem_before_modal.focus();
+                    current_modal_focusable = null;
+                }
+
+                clicked_inside_modal = false;
             }, 200);
 
-            _log("CookieConsent [MODAL]: show consent_modal");
-          },
-          delay > 0 ? delay : create_modal ? 30 : 0
-        );
-      }
-    };
+            _log("CookieConsent [SETTINGS]: hide settings_modal");
+        };
 
-    /**
-     * Hide consent modal
-     */
-    _cookieconsent.hide = function () {
-      if (consent_modal_exists) {
-        _removeClass(html_dom, "show--consent");
-        consent_modal.setAttribute("aria-hidden", "true");
-        consent_modal_visible = false;
-
-        setTimeout(function () {
-          //restore focus to the last page element which had focus before modal opening
-          last_elem_before_modal.focus();
-          current_modal_focusable = null;
-        }, 200);
-
-        _log("CookieConsent [MODAL]: hide");
-      }
-    };
-
-    /**
-     * Hide settings modal
-     */
-    _cookieconsent.hideSettings = function () {
-      _removeClass(html_dom, "show--settings");
-      settings_modal_visible = false;
-      settings_container.setAttribute("aria-hidden", "true");
-
-      setTimeout(function () {
         /**
-         * If consent modal is visible, focus him (instead of page document)
+         * Accept cookieconsent function API
+         * @param {string[]|string} _categories - Categories to accept
+         * @param {string[]} [_exclusions] - Excluded categories [optional]
          */
-        if (consent_modal_visible) {
-          last_consent_modal_btn_focus && last_consent_modal_btn_focus.focus();
-          current_modal_focusable = consent_modal_focusable;
-        } else {
-          /**
-           * Restore focus to last page element which had focus before modal opening
-           */
-          last_elem_before_modal && last_elem_before_modal.focus();
-          current_modal_focusable = null;
-        }
+        _cookieconsent.accept = function (_categories, _exclusions) {
+            var categories = _categories || undefined;
+            var exclusions = _exclusions || [];
+            var to_accept = [];
 
-        clicked_inside_modal = false;
-      }, 200);
+            /**
+             * Get all accepted categories
+             * @returns {string[]}
+             */
+            var _getCurrentPreferences = function () {
+                var toggles = document.querySelectorAll(".c-tgl") || [];
+                var states = [];
 
-      _log("CookieConsent [SETTINGS]: hide settings_modal");
-    };
+                for (var i = 0; i < toggles.length; i++) {
+                    if (toggles[i].checked) {
+                        states.push(toggles[i].value);
+                    }
+                }
+                return states;
+            };
 
-    /**
-     * Accept cookieconsent function API
-     * @param {string[]|string} _categories - Categories to accept
-     * @param {string[]} [_exclusions] - Excluded categories [optional]
-     */
-    _cookieconsent.accept = function (_categories, _exclusions) {
-      var categories = _categories || undefined;
-      var exclusions = _exclusions || [];
-      var to_accept = [];
-
-      /**
-       * Get all accepted categories
-       * @returns {string[]}
-       */
-      var _getCurrentPreferences = function () {
-        var toggles = document.querySelectorAll(".c-tgl") || [];
-        var states = [];
-
-        for (var i = 0; i < toggles.length; i++) {
-          if (toggles[i].checked) {
-            states.push(toggles[i].value);
-          }
-        }
-        return states;
-      };
-
-      if (!categories) {
-        to_accept = _getCurrentPreferences();
-      } else {
-        if (
-          typeof categories === "object" &&
-          typeof categories.length === "number"
-        ) {
-          for (var i = 0; i < categories.length; i++) {
-            if (_inArray(all_categories, categories[i]) !== -1)
-              to_accept.push(categories[i]);
-          }
-        } else if (typeof categories === "string") {
-          if (categories === "all") to_accept = all_categories.slice();
-          else {
-            if (_inArray(all_categories, categories) !== -1)
-              to_accept.push(categories);
-          }
-        }
-      }
-
-      // Remove excluded categories
-      if (exclusions.length >= 1) {
-        for (i = 0; i < exclusions.length; i++) {
-          to_accept = to_accept.filter(function (item) {
-            return item !== exclusions[i];
-          });
-        }
-      }
-
-      // Add back all the categories set as "readonly/required"
-      for (i = 0; i < all_categories.length; i++) {
-        if (
-          readonly_categories[i] === true &&
-          _inArray(to_accept, all_categories[i]) === -1
-        ) {
-          to_accept.push(all_categories[i]);
-        }
-      }
-
-      _saveCookiePreferences(to_accept);
-    };
-
-    /**
-     * API function to easily erase cookies
-     * @param {(string|string[])} _cookies
-     * @param {string} [_path] - optional
-     * @param {string} [_domain] - optional
-     */
-    _cookieconsent.eraseCookies = function (_cookies, _path, _domain) {
-      var cookies = [];
-      var domains = _domain
-        ? [_domain, "." + _domain]
-        : [_config.cookie_domain, "." + _config.cookie_domain];
-
-      if (typeof _cookies === "object" && _cookies.length > 0) {
-        for (var i = 0; i < _cookies.length; i++) {
-          this.validCookie(_cookies[i]) && cookies.push(_cookies[i]);
-        }
-      } else {
-        this.validCookie(_cookies) && cookies.push(_cookies);
-      }
-
-      _eraseCookies(cookies, _path, domains);
-    };
-
-    /**
-     * Set cookie, by specifying name and value
-     * @param {string} name
-     * @param {string} value
-     */
-    var _setCookie = function (name, value) {
-      var cookie_expiration = _config.cookie_expiration;
-
-      if (
-        typeof _config.cookie_necessary_only_expiration === "number" &&
-        accept_type === "necessary"
-      )
-        cookie_expiration = _config.cookie_necessary_only_expiration;
-
-      value = _config.use_rfc_cookie ? encodeURIComponent(value) : value;
-
-      var date = new Date();
-      date.setTime(date.getTime() + 1000 * (cookie_expiration * 24 * 60 * 60));
-      var expires = "; expires=" + date.toUTCString();
-
-      var cookieStr =
-        name +
-        "=" +
-        (value || "") +
-        expires +
-        "; Path=" +
-        _config.cookie_path +
-        ";";
-      cookieStr += " SameSite=" + _config.cookie_same_site + ";";
-
-      // assures cookie works with localhost (=> don't specify domain if on localhost)
-      if (window.location.hostname.indexOf(".") > -1) {
-        cookieStr += " Domain=" + _config.cookie_domain + ";";
-      }
-
-      if (window.location.protocol === "https:") {
-        cookieStr += " Secure;";
-      }
-
-      document.cookie = cookieStr;
-
-      _log(
-        "CookieConsent [SET_COOKIE]: cookie '" + name + "'=",
-        JSON.parse(value)
-      );
-      _log(
-        "CookieConsent [SET_COOKIE]: '" +
-          name +
-          "' expires after " +
-          cookie_expiration +
-          " day(s)"
-      );
-    };
-
-    /**
-     * Get cookie value by name,
-     * returns the cookie value if found (or an array
-     * of cookies if filter provided), otherwise empty string: ""
-     * @param {string} name
-     * @param {string} filter 'one' or 'all'
-     * @param {boolean} [get_value] set to true to obtain its value
-     * @returns {string|string[]}
-     */
-    var _getCookie = function (name, filter, get_value) {
-      var found;
-
-      if (filter === "one") {
-        found = document.cookie.match("(^|;)\\s*" + name + "\\s*=\\s*([^;]+)");
-        found = found ? (get_value ? found.pop() : name) : "";
-
-        if (found && name === _config.cookie_name) {
-          try {
-            found = JSON.parse(found);
-          } catch (e) {
-            try {
-              found = JSON.parse(decodeURIComponent(found));
-            } catch (e) {
-              // if I got here => cookie value is not a valid json string
-              found = {};
+            if (!categories) {
+                to_accept = _getCurrentPreferences();
+            } else {
+                if (
+                    typeof categories === "object" &&
+                    typeof categories.length === "number"
+                ) {
+                    for (var i = 0; i < categories.length; i++) {
+                        if (_inArray(all_categories, categories[i]) !== -1)
+                            to_accept.push(categories[i]);
+                    }
+                } else if (typeof categories === "string") {
+                    if (categories === "all")
+                        to_accept = all_categories.slice();
+                    else {
+                        if (_inArray(all_categories, categories) !== -1)
+                            to_accept.push(categories);
+                    }
+                }
             }
-          }
-          found = JSON.stringify(found);
-        }
-      } else if (filter === "all") {
-        // array of names of all existing cookies
-        var cookies = document.cookie.split(/;\s*/);
-        found = [];
-        for (var i = 0; i < cookies.length; i++) {
-          found.push(cookies[i].split("=")[0]);
-        }
-      }
 
-      return found;
+            // Remove excluded categories
+            if (exclusions.length >= 1) {
+                for (i = 0; i < exclusions.length; i++) {
+                    to_accept = to_accept.filter(function (item) {
+                        return item !== exclusions[i];
+                    });
+                }
+            }
+
+            // Add back all the categories set as "readonly/required"
+            for (i = 0; i < all_categories.length; i++) {
+                if (
+                    readonly_categories[i] === true &&
+                    _inArray(to_accept, all_categories[i]) === -1
+                ) {
+                    to_accept.push(all_categories[i]);
+                }
+            }
+
+            _saveCookiePreferences(to_accept);
+        };
+
+        /**
+         * API function to easily erase cookies
+         * @param {(string|string[])} _cookies
+         * @param {string} [_path] - optional
+         * @param {string} [_domain] - optional
+         */
+        _cookieconsent.eraseCookies = function (_cookies, _path, _domain) {
+            var cookies = [];
+            var domains = _domain
+                ? [_domain, "." + _domain]
+                : [_config.cookie_domain, "." + _config.cookie_domain];
+
+            if (typeof _cookies === "object" && _cookies.length > 0) {
+                for (var i = 0; i < _cookies.length; i++) {
+                    this.validCookie(_cookies[i]) && cookies.push(_cookies[i]);
+                }
+            } else {
+                this.validCookie(_cookies) && cookies.push(_cookies);
+            }
+
+            _eraseCookies(cookies, _path, domains);
+        };
+
+        /**
+         * Set cookie, by specifying name and value
+         * @param {string} name
+         * @param {string} value
+         */
+        var _setCookie = function (name, value) {
+            var cookie_expiration = _config.cookie_expiration;
+
+            if (
+                typeof _config.cookie_necessary_only_expiration === "number" &&
+                accept_type === "necessary"
+            )
+                cookie_expiration = _config.cookie_necessary_only_expiration;
+
+            value = _config.use_rfc_cookie ? encodeURIComponent(value) : value;
+
+            var date = new Date();
+            date.setTime(
+                date.getTime() + 1000 * (cookie_expiration * 24 * 60 * 60)
+            );
+            var expires = "; expires=" + date.toUTCString();
+
+            var cookieStr =
+                name +
+                "=" +
+                (value || "") +
+                expires +
+                "; Path=" +
+                _config.cookie_path +
+                ";";
+            cookieStr += " SameSite=" + _config.cookie_same_site + ";";
+
+            // assures cookie works with localhost (=> don't specify domain if on localhost)
+            if (window.location.hostname.indexOf(".") > -1) {
+                cookieStr += " Domain=" + _config.cookie_domain + ";";
+            }
+
+            if (window.location.protocol === "https:") {
+                cookieStr += " Secure;";
+            }
+
+            document.cookie = cookieStr;
+
+            _log(
+                "CookieConsent [SET_COOKIE]: cookie '" + name + "'=",
+                JSON.parse(value)
+            );
+            _log(
+                "CookieConsent [SET_COOKIE]: '" +
+                    name +
+                    "' expires after " +
+                    cookie_expiration +
+                    " day(s)"
+            );
+        };
+
+        /**
+         * Get cookie value by name,
+         * returns the cookie value if found (or an array
+         * of cookies if filter provided), otherwise empty string: ""
+         * @param {string} name
+         * @param {string} filter 'one' or 'all'
+         * @param {boolean} [get_value] set to true to obtain its value
+         * @returns {string|string[]}
+         */
+        var _getCookie = function (name, filter, get_value) {
+            var found;
+
+            if (filter === "one") {
+                found = document.cookie.match(
+                    "(^|;)\\s*" + name + "\\s*=\\s*([^;]+)"
+                );
+                found = found ? (get_value ? found.pop() : name) : "";
+
+                if (found && name === _config.cookie_name) {
+                    try {
+                        found = JSON.parse(found);
+                    } catch (e) {
+                        try {
+                            found = JSON.parse(decodeURIComponent(found));
+                        } catch (e) {
+                            // if I got here => cookie value is not a valid json string
+                            found = {};
+                        }
+                    }
+                    found = JSON.stringify(found);
+                }
+            } else if (filter === "all") {
+                // array of names of all existing cookies
+                var cookies = document.cookie.split(/;\s*/);
+                found = [];
+                for (var i = 0; i < cookies.length; i++) {
+                    found.push(cookies[i].split("=")[0]);
+                }
+            }
+
+            return found;
+        };
+
+        /**
+         * Delete cookie by name & path
+         * @param {string[]} cookies
+         * @param {string} [custom_path] - optional
+         * @param {string[]} domains - example: ['domain.com', '.domain.com']
+         */
+        var _eraseCookies = function (cookies, custom_path, domains) {
+            var path = custom_path ? custom_path : "/";
+            var expires = "Expires=Thu, 01 Jan 1970 00:00:01 GMT;";
+
+            for (var i = 0; i < cookies.length; i++) {
+                for (var j = 0; j < domains.length; j++) {
+                    document.cookie =
+                        cookies[i] +
+                        "=; path=" +
+                        path +
+                        (domains[j].indexOf(".") > -1
+                            ? "; domain=" + domains[j]
+                            : "") +
+                        "; " +
+                        expires;
+                }
+                _log(
+                    "CookieConsent [AUTOCLEAR]: deleting cookie: '" +
+                        cookies[i] +
+                        "' path: '" +
+                        path +
+                        "' domain:",
+                    domains
+                );
+            }
+        };
+
+        /**
+         * Returns true if cookie was found and has valid value (not empty string)
+         * @param {string} cookie_name
+         * @returns {boolean}
+         */
+        _cookieconsent.validCookie = function (cookie_name) {
+            return _getCookie(cookie_name, "one", true) !== "";
+        };
+
+        /**
+         * Function to run when event is fired
+         * @callback eventFired
+         */
+
+        /**
+         * Add event listener to dom object (cross browser function)
+         * @param {Element} elem
+         * @param {string} event
+         * @param {eventFired} fn
+         * @param {boolean} [isPassive]
+         */
+        var _addEvent = function (elem, event, fn, isPassive) {
+            elem.addEventListener(
+                event,
+                fn,
+                isPassive === true ? { passive: true } : false
+            );
+        };
+
+        /**
+         * Get all prop. keys defined inside object
+         * @param {Object} obj
+         */
+        var _getKeys = function (obj) {
+            if (typeof obj === "object") {
+                return Object.keys(obj);
+            }
+        };
+
+        /**
+         * Append class to the specified dom element
+         * @param {HTMLElement} elem
+         * @param {string} classname
+         */
+        var _addClass = function (elem, classname) {
+            elem.classList.add(classname);
+        };
+
+        /**
+         * Remove specified class from dom element
+         * @param {HTMLElement} elem
+         * @param {string} classname
+         */
+        var _removeClass = function (el, className) {
+            el.classList.remove(className);
+        };
+
+        /**
+         * Check if html element has class
+         * @param {HTMLElement} el
+         * @param {string} className
+         */
+        var _hasClass = function (el, className) {
+            return el.classList.contains(className);
+        };
+
+        return _cookieconsent;
     };
 
+    var init = "initCookieConsent";
     /**
-     * Delete cookie by name & path
-     * @param {string[]} cookies
-     * @param {string} [custom_path] - optional
-     * @param {string[]} domains - example: ['domain.com', '.domain.com']
+     * Make CookieConsent object accessible globally
      */
-    var _eraseCookies = function (cookies, custom_path, domains) {
-      var path = custom_path ? custom_path : "/";
-      var expires = "Expires=Thu, 01 Jan 1970 00:00:01 GMT;";
-
-      for (var i = 0; i < cookies.length; i++) {
-        for (var j = 0; j < domains.length; j++) {
-          document.cookie =
-            cookies[i] +
-            "=; path=" +
-            path +
-            (domains[j].indexOf(".") > -1 ? "; domain=" + domains[j] : "") +
-            "; " +
-            expires;
-        }
-        _log(
-          "CookieConsent [AUTOCLEAR]: deleting cookie: '" +
-            cookies[i] +
-            "' path: '" +
-            path +
-            "' domain:",
-          domains
-        );
-      }
-    };
-
-    /**
-     * Returns true if cookie was found and has valid value (not empty string)
-     * @param {string} cookie_name
-     * @returns {boolean}
-     */
-    _cookieconsent.validCookie = function (cookie_name) {
-      return _getCookie(cookie_name, "one", true) !== "";
-    };
-
-    /**
-     * Function to run when event is fired
-     * @callback eventFired
-     */
-
-    /**
-     * Add event listener to dom object (cross browser function)
-     * @param {Element} elem
-     * @param {string} event
-     * @param {eventFired} fn
-     * @param {boolean} [isPassive]
-     */
-    var _addEvent = function (elem, event, fn, isPassive) {
-      elem.addEventListener(
-        event,
-        fn,
-        isPassive === true ? { passive: true } : false
-      );
-    };
-
-    /**
-     * Get all prop. keys defined inside object
-     * @param {Object} obj
-     */
-    var _getKeys = function (obj) {
-      if (typeof obj === "object") {
-        return Object.keys(obj);
-      }
-    };
-
-    /**
-     * Append class to the specified dom element
-     * @param {HTMLElement} elem
-     * @param {string} classname
-     */
-    var _addClass = function (elem, classname) {
-      elem.classList.add(classname);
-    };
-
-    /**
-     * Remove specified class from dom element
-     * @param {HTMLElement} elem
-     * @param {string} classname
-     */
-    var _removeClass = function (el, className) {
-      el.classList.remove(className);
-    };
-
-    /**
-     * Check if html element has class
-     * @param {HTMLElement} el
-     * @param {string} className
-     */
-    var _hasClass = function (el, className) {
-      return el.classList.contains(className);
-    };
-
-    return _cookieconsent;
-  };
-
-  var init = "initCookieConsent";
-  /**
-   * Make CookieConsent object accessible globally
-   */
-  if (typeof window !== "undefined" && typeof window[init] !== "function") {
-    window[init] = CookieConsent;
-  }
+    if (typeof window !== "undefined" && typeof window[init] !== "function") {
+        window[init] = CookieConsent;
+    }
 })();

--- a/src/cookieconsent.js
+++ b/src/cookieconsent.js
@@ -591,19 +591,35 @@
         consent_modal.appendChild(consent_modal_inner);
       }
 
-      // add links to privacy and imprint
+      // add links to privacy policy and imprint to modal
       const consent_links = _createNode("div");
       consent_links.id = "c-link";
 
-      const consent_links_imprint = _createNode("div");
-      consent_links_imprint.classList.add("cc-link");
-      consent_links_imprint.innerHTML = `<a href="/imprint">Imprint</a>`;
-      consent_links.appendChild(consent_links_imprint);
+      const imprint_link =
+        user_config.languages[lang]["consent_modal"]["imprint_link"];
+      if (imprint_link) {
+        const i_link = imprint_link["url"];
+        const i_text = imprint_link["text"];
 
-      const consent_links_privacy = _createNode("div");
-      consent_links_privacy.classList.add("cc-link");
-      consent_links_privacy.innerHTML = `<a href="/privacy">Privacy</a>`;
-      consent_links.appendChild(consent_links_privacy);
+        const consent_links_imprint = _createNode("a");
+        consent_links_imprint.classList.add("cc-link");
+        consent_links_imprint.textContent = i_text;
+        consent_links_imprint.setAttribute("href", i_link);
+        consent_links.appendChild(consent_links_imprint);
+      }
+
+      const privacy_policy_link =
+        user_config.languages[lang]["consent_modal"]["privacy_policy_link"];
+      if (privacy_policy_link) {
+        const p_link = privacy_policy_link["url"];
+        const p_text = privacy_policy_link["text"];
+
+        const consent_links_privacy = _createNode("a");
+        consent_links_privacy.classList.add("cc-link");
+        consent_links_privacy.textContent = p_text;
+        consent_links_privacy.setAttribute("href", p_link);
+        consent_links.appendChild(consent_links_privacy);
+      }
 
       consent_modal_inner.appendChild(consent_links);
 

--- a/src/cookieconsent.js
+++ b/src/cookieconsent.js
@@ -4,2224 +4,2423 @@
  * Author Orest Bida
  * Released under the MIT License
  */
-(function(){
-    'use strict';
+(function () {
+  "use strict";
+  /**
+   * @param {HTMLElement} [root] - [optional] element where the cookieconsent will be appended
+   * @returns {Object} cookieconsent object with API
+   */
+  var CookieConsent = function (root) {
     /**
-     * @param {HTMLElement} [root] - [optional] element where the cookieconsent will be appended
-     * @returns {Object} cookieconsent object with API
+     * CHANGE THIS FLAG FALSE TO DISABLE console.log()
      */
-    var CookieConsent = function(root){
-
-        /**
-         * CHANGE THIS FLAG FALSE TO DISABLE console.log()
-         */
-        var ENABLE_LOGS = true;
-
-        var _config = {
-            'mode': 'opt-in',                         // 'opt-in', 'opt-out'
-            'current_lang': 'en',
-            'auto_language': null,
-            'autorun': true,                          // run as soon as loaded
-            'page_scripts': true,
-            'hide_from_bots': true,
-            'cookie_name': 'cc_cookie',
-            'cookie_expiration': 182,                 // default: 6 months (in days)
-            'cookie_domain': window.location.hostname,       // default: current domain
-            'cookie_path': '/',
-            'cookie_same_site': 'Lax',
-            'use_rfc_cookie': false,
-            'autoclear_cookies': true,
-            'revision': 0,
-            'script_selector': 'data-cookiecategory'
-        };
-
-        var
-            /**
-             * Object which holds the main methods/API (.show, .run, ...)
-            */
-            _cookieconsent = {},
-
-            /**
-             * Global user configuration object
-             */
-            user_config,
-
-            /**
-             * Internal state variables
-             */
-            saved_cookie_content = {},
-            cookie_data = null,
-
-            /**
-             * @type {Date}
-             */
-            consent_date,
-
-            /**
-             * @type {Date}
-             */
-            last_consent_update,
-
-            /**
-             * @type {string}
-             */
-            consent_uuid,
-
-            /**
-             * @type {boolean}
-             */
-            invalid_consent = true,
-
-            consent_modal_exists = false,
-            consent_modal_visible = false,
-
-            settings_modal_visible = false,
-            clicked_inside_modal = false,
-            current_modal_focusable,
-
-            all_table_headers,
-            all_blocks,
-
-            // Helper callback functions
-            // (avoid calling "user_config['onAccept']" all the time)
-            onAccept,
-            onChange,
-            onFirstAction,
-
-            revision_enabled = false,
-            valid_revision = true,
-            revision_message = '',
-
-            // State variables for the autoclearCookies function
-            changed_settings = [],
-            reload_page = false;
-
-        /**
-         * Accept type:
-         *  - "all"
-         *  - "necessary"
-         *  - "custom"
-         * @type {string}
-         */
-        var accept_type;
-
-        /**
-         * Contains all accepted categories
-         * @type {string[]}
-         */
-        var accepted_categories = [];
-
-        /**
-         * Contains all non-accepted (rejected) categories
-         * @type {string[]}
-         */
-        var rejected_categories = [];
-
-        /**
-         * Contains all categories enabled by default
-         * @type {string[]}
-         */
-        var default_enabled_categories = [];
-
-        // Don't run plugin (to avoid indexing its text content) if bot detected
-        var is_bot = false;
-
-        /**
-         * Save reference to the last focused element on the page
-         * (used later to restore focus when both modals are closed)
-         */
-        var last_elem_before_modal;
-        var last_consent_modal_btn_focus;
-
-        /**
-         * Both of the arrays below have the same structure:
-         * [0] => holds reference to the FIRST focusable element inside modal
-         * [1] => holds reference to the LAST focusable element inside modal
-         */
-        var consent_modal_focusable = [];
-        var settings_modal_focusable = [];
-
-        /**
-         * Keep track of enabled/disabled categories
-         * @type {boolean[]}
-         */
-        var toggle_states = [];
-
-        /**
-         * Stores all available categories
-         * @type {string[]}
-         */
-        var all_categories = [];
-
-        /**
-         * Keep track of readonly toggles
-         * @type {boolean[]}
-         */
-        var readonly_categories = [];
-
-        /**
-         * Pointers to main dom elements (to avoid retrieving them later using document.getElementById)
-         */
-        var
-            /** @type {HTMLElement} */ html_dom = document.documentElement,
-            /** @type {HTMLElement} */ main_container,
-            /** @type {HTMLElement} */ all_modals_container,
-
-            /** @type {HTMLElement} */ consent_modal,
-            /** @type {HTMLElement} */ consent_modal_title,
-            /** @type {HTMLElement} */ consent_modal_description,
-            /** @type {HTMLElement} */ consent_primary_btn,
-            /** @type {HTMLElement} */ consent_secondary_btn,
-            /** @type {HTMLElement} */ consent_buttons,
-            /** @type {HTMLElement} */ consent_modal_inner,
-
-            /** @type {HTMLElement} */ settings_container,
-            /** @type {HTMLElement} */ settings_inner,
-            /** @type {HTMLElement} */ settings_title,
-            /** @type {HTMLElement} */ settings_close_btn,
-            /** @type {HTMLElement} */ settings_blocks,
-            /** @type {HTMLElement} */ new_settings_blocks,
-            /** @type {HTMLElement} */ settings_buttons,
-            /** @type {HTMLElement} */ settings_save_btn,
-            /** @type {HTMLElement} */ settings_accept_all_btn,
-            /** @type {HTMLElement} */ settings_reject_all_btn;
-
-        /**
-         * Update config settings
-         * @param {Object} user_config
-         */
-        var _setConfig = function(_user_config){
-
-            /**
-             * Make user configuration globally available
-             */
-            user_config = _user_config;
-
-            _log("CookieConsent [CONFIG]: received_config_settings ", user_config);
-
-            if(typeof user_config['cookie_expiration'] === "number")
-                _config.cookie_expiration = user_config['cookie_expiration'];
-
-            if(typeof user_config['cookie_necessary_only_expiration'] === "number")
-                _config.cookie_necessary_only_expiration  = user_config['cookie_necessary_only_expiration'];
-
-            if(typeof user_config['autorun'] === "boolean")
-                _config.autorun = user_config['autorun'];
-
-            if(typeof user_config['cookie_domain'] === "string")
-                _config.cookie_domain = user_config['cookie_domain'];
-
-            if(typeof user_config['cookie_same_site'] === "string")
-                _config.cookie_same_site = user_config['cookie_same_site'];
-
-            if(typeof user_config['cookie_path'] === "string")
-                _config.cookie_path = user_config['cookie_path'];
-
-            if(typeof user_config['cookie_name'] === "string")
-                _config.cookie_name = user_config['cookie_name'];
-
-            if(typeof user_config['onAccept'] === "function")
-                onAccept = user_config['onAccept'];
-
-            if(typeof user_config['onFirstAction'] === "function")
-                onFirstAction = user_config['onFirstAction'];
-
-            if(typeof user_config['onChange'] === "function")
-                onChange = user_config['onChange'];
-
-            if(user_config['mode'] === 'opt-out')
-                _config.mode = 'opt-out';
-
-            if(typeof user_config['revision'] === "number"){
-                user_config['revision'] > -1 && (_config.revision = user_config['revision']);
-                revision_enabled = true;
-            }
-
-            if(typeof user_config['autoclear_cookies'] === "boolean")
-                _config.autoclear_cookies = user_config['autoclear_cookies'];
-
-            if(user_config['use_rfc_cookie'] === true)
-                _config.use_rfc_cookie = true;
-
-            if(user_config['hide_from_bots'] === true){
-                is_bot = navigator &&
-                    ((navigator.userAgent && /bot|crawl|spider|slurp|teoma/i.test(navigator.userAgent)) || navigator.webdriver);
-            }
-
-            _config.page_scripts = user_config['page_scripts'] === true;
-
-            if (user_config['auto_language'] === 'browser' || user_config['auto_language'] === true) {
-                _config.auto_language = 'browser';
-            } else if (user_config['auto_language'] === 'document') {
-                _config.auto_language = 'document';
-            }
-
-            _log("CookieConsent [LANG]: auto_language strategy is '" + _config.auto_language + "'");
-
-            _config.current_lang = _resolveCurrentLang(user_config.languages, user_config['current_lang']);
-        }
-
-        // /**
-        //  * Print consent date
-        //  */
-        // var _printConsentDateHTML = function(){
-        //     if(!consent_date) return;
-
-        //     var consent_date_elements = document.querySelectorAll('[data-cc="consent-date"]');
-        //     var last_consent_update_elements = document.querySelectorAll('[data-cc="last-consent-update"]');
-
-        //     for(var i=0; i<consent_date_elements.length; i++)
-        //         consent_date_elements[i].textContent = consent_date.toLocaleString();
-
-        //     for(var i=0; i<last_consent_update_elements.length; i++)
-        //         last_consent_update_elements[i].textContent = last_consent_update.toLocaleString();
-        // }
-
-        /**
-         * Add an onClick listeners to all html elements with data-cc attribute
-         */
-        var _addDataButtonListeners = function(elem){
-
-            var _a = 'accept-';
-
-            var show_settings = _getElements('c-settings');
-            var accept_all = _getElements(_a + 'all');
-            var accept_necessary = _getElements(_a + 'necessary');
-            var accept_custom_selection = _getElements(_a + 'custom');
-
-            for(var i=0; i<show_settings.length; i++){
-                show_settings[i].setAttribute('aria-haspopup', 'dialog');
-                _addEvent(show_settings[i], 'click', function(event){
-                    event.preventDefault();
-                    _cookieconsent.showSettings(0);
-                });
-            }
-
-            for(i=0; i<accept_all.length; i++){
-                _addEvent(accept_all[i], 'click', function(event){
-                    _acceptAction(event, 'all');
-                });
-            }
-
-            for(i=0; i<accept_custom_selection.length; i++){
-                _addEvent(accept_custom_selection[i], 'click', function(event){
-                    _acceptAction(event);
-                });
-            }
-
-            for(i=0; i<accept_necessary.length; i++){
-                _addEvent(accept_necessary[i], 'click', function(event){
-                    _acceptAction(event, []);
-                });
-            }
-
-            /**
-             * Return all elements with given data-cc role
-             * @param {string} data_role
-             * @returns {NodeListOf<Element>}
-             */
-            function _getElements(data_role){
-                return (elem || document).querySelectorAll('a[data-cc="' + data_role + '"], button[data-cc="' + data_role + '"]');
-            }
-
-            /**
-             * Helper function: accept and then hide modals
-             * @param {PointerEvent} e source event
-             * @param {string} [accept_type]
-             */
-            function _acceptAction(e, accept_type){
-                e.preventDefault();
-                _cookieconsent.accept(accept_type);
-                _cookieconsent.hideSettings();
-                _cookieconsent.hide();
-            }
-
-            //_printConsentDateHTML();
-        }
-
-        /**
-         * Get a valid language (at least 1 must be defined)
-         * @param {string} lang - desired language
-         * @param {Object} all_languages - all defined languages
-         * @returns {string} validated language
-         */
-        var _getValidatedLanguage = function(lang, all_languages){
-            if(Object.prototype.hasOwnProperty.call(all_languages, lang)){
-                return lang;
-            }else if(_getKeys(all_languages).length > 0){
-                if(Object.prototype.hasOwnProperty.call(all_languages, _config.current_lang)){
-                    return _config.current_lang ;
-                }else{
-                    return _getKeys(all_languages)[0];
-                }
-            }
-        }
-
-        /**
-         * Save reference to first and last focusable elements inside each modal
-         * to prevent losing focus while navigating with TAB
-         */
-        var _getModalFocusableData = function(){
-
-            /**
-             * Note: any of the below focusable elements, which has the attribute tabindex="-1" AND is either
-             * the first or last element of the modal, won't receive focus during "open/close" modal
-             */
-            var allowed_focusable_types = ['[href]', 'button', 'input', 'details', '[tabindex="0"]'];
-
-            function _getAllFocusableElements(modal, _array){
-                var focus_later=false, focus_first=false;
-
-                // ie might throw exception due to complex unsupported selector => a:not([tabindex="-1"])
-                try{
-                    var focusable_elems = modal.querySelectorAll(allowed_focusable_types.join(':not([tabindex="-1"]), '));
-                    var attr, len=focusable_elems.length, i=0;
-
-                    while(i < len){
-
-                        attr = focusable_elems[i].getAttribute('data-focus');
-
-                        if(!focus_first && attr === "1"){
-                            focus_first = focusable_elems[i];
-
-                        }else if(attr === "0"){
-                            focus_later = focusable_elems[i];
-                            if(!focus_first && focusable_elems[i+1].getAttribute('data-focus') !== "0"){
-                                focus_first = focusable_elems[i+1];
-                            }
-                        }
-
-                        i++;
-                    }
-
-                }catch(e){
-                    return modal.querySelectorAll(allowed_focusable_types.join(', '));
-                }
-
-                /**
-                 * Save first and last elements (used to lock/trap focus inside modal)
-                 */
-                _array[0] = focusable_elems[0];
-                _array[1] = focusable_elems[focusable_elems.length - 1];
-                _array[2] = focus_later;
-                _array[3] = focus_first;
-            }
-
-            /**
-             * Get settings modal'S all focusable elements
-             * Save first and last elements (used to lock/trap focus inside modal)
-             */
-            _getAllFocusableElements(settings_inner, settings_modal_focusable);
-
-            /**
-             * If consent modal exists, do the same
-             */
-            if(consent_modal_exists){
-                _getAllFocusableElements(consent_modal, consent_modal_focusable);
-            }
-        }
-
-        var _createConsentModal = function(lang){
-
-            if(user_config['force_consent'] === true)
-                _addClass(html_dom, 'force--consent');
-
-            // Create modal if it doesn't exist
-            if(!consent_modal){
-
-                consent_modal = _createNode('div');
-                var consent_modal_inner_inner = _createNode('div');
-                var overlay = _createNode('div');
-
-                consent_modal.id = 'cm';
-                consent_modal_inner_inner.id = 'c-inr-i';
-                overlay.id = 'cm-ov';
-
-                consent_modal.setAttribute('role', 'dialog');
-                consent_modal.setAttribute('aria-modal', 'true');
-                consent_modal.setAttribute('aria-hidden', 'false');
-                consent_modal.setAttribute('aria-labelledby', 'c-ttl');
-                consent_modal.setAttribute('aria-describedby', 'c-txt');
-
-                // Append consent modal to main container
-                all_modals_container.appendChild(consent_modal);
-                all_modals_container.appendChild(overlay);
-
-                /**
-                 * Make modal by default hidden to prevent weird page jumps/flashes (shown only once css is loaded)
-                 */
-                consent_modal.style.visibility = overlay.style.visibility = "hidden";
-                overlay.style.opacity = 0;
-            }
-
-            // Use insertAdjacentHTML instead of innerHTML
-            var consent_modal_title_value = user_config.languages[lang]['consent_modal']['title'];
-
-            // Add title (if valid)
-            if(consent_modal_title_value){
-
-                if(!consent_modal_title){
-                    consent_modal_title = _createNode('div');
-                    consent_modal_title.id = 'c-ttl';
-                    consent_modal_title.setAttribute('role', 'heading');
-                    consent_modal_title.setAttribute('aria-level', '2');
-                    consent_modal_inner_inner.appendChild(consent_modal_title);
-                }
-
-                consent_modal_title.innerHTML = consent_modal_title_value;
-            }
-
-            var description = user_config.languages[lang]['consent_modal']['description'];
-
-            if(revision_enabled){
-                if(!valid_revision){
-                    description = description.replace("{{revision_message}}", revision_message || user_config.languages[lang]['consent_modal']['revision_message'] || "");
-                }else{
-                    description = description.replace("{{revision_message}}", "");
-                }
-            }
-
-            if(!consent_modal_description){
-                consent_modal_description = _createNode('div');
-                consent_modal_description.id = 'c-txt';
-                consent_modal_inner_inner.appendChild(consent_modal_description);
-            }
-
-            // Set description content
-            consent_modal_description.innerHTML = description;
-
-            var primary_btn_data = user_config.languages[lang]['consent_modal']['primary_btn'],   // accept current selection
-                secondary_btn_data = user_config.languages[lang]['consent_modal']['secondary_btn'];
-
-            // Add primary button if not falsy
-            if(primary_btn_data){
-
-                if(!consent_primary_btn){
-                    consent_primary_btn = _createNode('button');
-                    consent_primary_btn.id = 'c-p-bn';
-                    consent_primary_btn.className =  "c-bn";
-
-                    var _accept_type;
-
-                    if(primary_btn_data['role'] === 'accept_all')
-                        _accept_type = 'all'
-
-                    _addEvent(consent_primary_btn, "click", function(){
-                        _cookieconsent.hide();
-                        _log("CookieConsent [ACCEPT]: cookie_consent was accepted!");
-                        _cookieconsent.accept(_accept_type);
-                    });
-                }
-
-                consent_primary_btn.innerHTML = user_config.languages[lang]['consent_modal']['primary_btn']['text'];
-            }
-
-            // Add secondary button if not falsy
-            if(secondary_btn_data){
-
-                if(!consent_secondary_btn){
-                    consent_secondary_btn = _createNode('button');
-                    consent_secondary_btn.id = 'c-s-bn';
-                    consent_secondary_btn.className = "c-bn c_link";
-
-                    if(secondary_btn_data['role'] === 'accept_necessary'){
-                        _addEvent(consent_secondary_btn, 'click', function(){
-                            _cookieconsent.hide();
-                            _cookieconsent.accept([]); // accept necessary only
-                        });
-                    }else{
-                        _addEvent(consent_secondary_btn, 'click', function(){
-                            _cookieconsent.showSettings(0);
-                        });
-                    }
-                }
-
-                consent_secondary_btn.innerHTML = user_config.languages[lang]['consent_modal']['secondary_btn']['text'];
-            }
-
-            // Swap buttons
-            var gui_options_data = user_config['gui_options'];
-
-            if(!consent_modal_inner){
-                consent_modal_inner = _createNode('div');
-                consent_modal_inner.id = 'c-inr';
-
-                consent_modal_inner.appendChild(consent_modal_inner_inner);
-            }
-
-            if(!consent_buttons){
-                consent_buttons = _createNode('div');
-                consent_buttons.id = "c-bns";
-
-                if(gui_options_data && gui_options_data['consent_modal'] && gui_options_data['consent_modal']['swap_buttons'] === true){
-                    secondary_btn_data && consent_buttons.appendChild(consent_secondary_btn);
-                    primary_btn_data && consent_buttons.appendChild(consent_primary_btn);
-                    consent_buttons.className = 'swap';
-                }else{
-                    primary_btn_data && consent_buttons.appendChild(consent_primary_btn);
-                    secondary_btn_data && consent_buttons.appendChild(consent_secondary_btn);
-                }
-
-                (primary_btn_data || secondary_btn_data ) && consent_modal_inner.appendChild(consent_buttons);
-                consent_modal.appendChild(consent_modal_inner);
-            }
-
-            consent_modal_exists = true;
-        }
-
-        var _createSettingsModal = function(lang){
-
-            /**
-             * Create all consent_modal elements
-             */
-            if(!settings_container){
-                settings_container = _createNode('div');
-                var settings_container_valign = _createNode('div');
-                var settings = _createNode('div');
-                var settings_container_inner = _createNode('div');
-                settings_inner = _createNode('div');
-                settings_title = _createNode('div');
-                var settings_header = _createNode('div');
-                settings_close_btn = _createNode('button');
-                var settings_close_btn_container = _createNode('div');
-                settings_blocks = _createNode('div');
-                var overlay = _createNode('div');
-
-                /**
-                 * Set ids
-                 */
-                settings_container.id = 's-cnt';
-                settings_container_valign.id = "c-vln";
-                settings_container_inner.id = "c-s-in";
-                settings.id = "cs";
-                settings_title.id = 's-ttl';
-                settings_inner.id = 's-inr';
-                settings_header.id = "s-hdr";
-                settings_blocks.id = 's-bl';
-                settings_close_btn.id = 's-c-bn';
-                overlay.id = 'cs-ov';
-                settings_close_btn_container.id = 's-c-bnc';
-                settings_close_btn.className = 'c-bn';
-
-                settings_container.setAttribute('role', 'dialog');
-                settings_container.setAttribute('aria-modal', 'true');
-                settings_container.setAttribute('aria-hidden', 'true');
-                settings_container.setAttribute('aria-labelledby', 's-ttl');
-                settings_title.setAttribute('role', 'heading');
-                settings_container.style.visibility = overlay.style.visibility = "hidden";
-                overlay.style.opacity = 0;
-
-                settings_close_btn_container.appendChild(settings_close_btn);
-
-                // If 'esc' key is pressed inside settings_container div => hide settings
-                _addEvent(settings_container_valign, 'keydown', function(evt){
-                    evt = evt || window.event;
-                    if (evt.keyCode === 27) {
-                        _cookieconsent.hideSettings(0);
-                    }
-                }, true);
-
-                _addEvent(settings_close_btn, 'click', function(){
-                    _cookieconsent.hideSettings(0);
-                });
-            }else{
-                new_settings_blocks = _createNode('div');
-                new_settings_blocks.id = 's-bl';
-            }
-
-            // Add label to close button
-            settings_close_btn.setAttribute('aria-label', user_config.languages[lang]['settings_modal']['close_btn_label'] || 'Close');
-
-            all_blocks = user_config.languages[lang]['settings_modal']['blocks'];
-            all_table_headers = user_config.languages[lang]['settings_modal']['cookie_table_headers'];
-
-            var n_blocks = all_blocks.length;
-
-            // Set settings modal title
-            settings_title.innerHTML = user_config.languages[lang]['settings_modal']['title'];
-
-            // Create settings modal content (blocks)
-            for(var i=0; i<n_blocks; ++i){
-
-                var title_data = all_blocks[i]['title'],
-                    description_data = all_blocks[i]['description'],
-                    toggle_data = all_blocks[i]['toggle'],
-                    cookie_table_data = all_blocks[i]['cookie_table'],
-                    remove_cookie_tables = user_config['remove_cookie_tables'] === true,
-                    isExpandable = (description_data && 'truthy') || (!remove_cookie_tables && (cookie_table_data && 'truthy'));
-
-                // Create title
-                var block_section = _createNode('div');
-                var block_table_container = _createNode('div');
-
-                // Create description
-                if(description_data){
-                    var block_desc = _createNode('div');
-                    block_desc.className = 'p';
-                    block_desc.insertAdjacentHTML('beforeend', description_data);
-                }
-
-                var block_title_container = _createNode('div');
-                block_title_container.className = 'title';
-
-                block_section.className = 'c-bl';
-                block_table_container.className = 'desc';
-
-                // Create toggle if specified (opt in/out)
-                if(typeof toggle_data !== 'undefined'){
-
-                    var accordion_id = "c-ac-"+i;
-
-                    // Create button (to collapse/expand block description)
-                    var block_title_btn = isExpandable ? _createNode('button') : _createNode('div');
-                    var block_switch_label = _createNode('label');
-                    var block_switch = _createNode('input');
-                    var block_switch_span = _createNode('span');
-                    var label_text_span = _createNode('span');
-
-                    // These 2 spans will contain each 2 pseudo-elements to generate 'tick' and 'x' icons
-                    var block_switch_span_on_icon = _createNode('span');
-                    var block_switch_span_off_icon = _createNode('span');
-
-                    block_title_btn.className = isExpandable ? 'b-tl exp' : 'b-tl';
-                    block_switch_label.className = 'b-tg';
-                    block_switch.className = 'c-tgl';
-                    block_switch_span_on_icon.className = 'on-i';
-                    block_switch_span_off_icon.className = 'off-i';
-                    block_switch_span.className = 'c-tg';
-                    label_text_span.className = "t-lb";
-
-                    if(isExpandable){
-                        block_title_btn.setAttribute('aria-expanded', 'false');
-                        block_title_btn.setAttribute('aria-controls', accordion_id);
-                    }
-
-                    block_switch.type = 'checkbox';
-                    block_switch_span.setAttribute('aria-hidden', 'true');
-
-                    var cookie_category = toggle_data.value;
-                    block_switch.value = cookie_category;
-
-                    label_text_span.textContent = title_data;
-                    block_title_btn.insertAdjacentHTML('beforeend', title_data);
-
-                    block_title_container.appendChild(block_title_btn);
-                    block_switch_span.appendChild(block_switch_span_on_icon);
-                    block_switch_span.appendChild(block_switch_span_off_icon);
-
-                    /**
-                     * If consent is valid => retrieve category states from cookie
-                     * Otherwise use states defined in the user_config. object
-                     */
-                    if(!invalid_consent){
-                        if(_inArray(saved_cookie_content['categories'], cookie_category) > -1){
-                            block_switch.checked = true;
-                            !new_settings_blocks && toggle_states.push(true);
-                        }else{
-                            !new_settings_blocks && toggle_states.push(false);
-                        }
-                    }else if(toggle_data['enabled']){
-                        block_switch.checked = true;
-                        !new_settings_blocks && toggle_states.push(true);
-
-                        /**
-                         * Keep track of categories enabled by default (useful when mode=='opt-out')
-                         */
-                        if(toggle_data['enabled'])
-                            !new_settings_blocks && default_enabled_categories.push(cookie_category);
-
-                    }else{
-                        !new_settings_blocks && toggle_states.push(false);
-                    }
-
-                    !new_settings_blocks && all_categories.push(cookie_category);
-
-                    /**
-                     * Set toggle as readonly if true (disable checkbox)
-                     */
-                    if(toggle_data['readonly']){
-                        block_switch.disabled = true;
-                        _addClass(block_switch_span, 'c-ro');
-                        !new_settings_blocks && readonly_categories.push(true);
-                    }else{
-                        !new_settings_blocks && readonly_categories.push(false);
-                    }
-
-                    _addClass(block_table_container, 'b-acc');
-                    _addClass(block_title_container, 'b-bn');
-                    _addClass(block_section, 'b-ex');
-
-                    block_table_container.id = accordion_id;
-                    block_table_container.setAttribute('aria-hidden', 'true');
-
-                    block_switch_label.appendChild(block_switch);
-                    block_switch_label.appendChild(block_switch_span);
-                    block_switch_label.appendChild(label_text_span);
-                    block_title_container.appendChild(block_switch_label);
-
-                    /**
-                     * On button click handle the following :=> aria-expanded, aria-hidden and act class for current block
-                     */
-                    isExpandable && (function(accordion, block_section, btn){
-                        _addEvent(block_title_btn, 'click', function(){
-                            if(!_hasClass(block_section, 'act')){
-                                _addClass(block_section, 'act');
-                                btn.setAttribute('aria-expanded', 'true');
-                                accordion.setAttribute('aria-hidden', 'false');
-                            }else{
-                                _removeClass(block_section, 'act');
-                                btn.setAttribute('aria-expanded', 'false');
-                                accordion.setAttribute('aria-hidden', 'true');
-                            }
-                        }, false);
-                    })(block_table_container, block_section, block_title_btn);
-
-                }else{
-                    /**
-                     * If block is not a button (no toggle defined),
-                     * create a simple div instead
-                     */
-                    if(title_data){
-                        var block_title = _createNode('div');
-                        block_title.className = 'b-tl';
-                        block_title.setAttribute('role', 'heading');
-                        block_title.setAttribute('aria-level', '3');
-                        block_title.insertAdjacentHTML('beforeend', title_data);
-                        block_title_container.appendChild(block_title);
-                    }
-                }
-
-                title_data && block_section.appendChild(block_title_container);
-                description_data && block_table_container.appendChild(block_desc);
-
-                // if cookie table found, generate table for this block
-                if(!remove_cookie_tables && typeof cookie_table_data !== 'undefined'){
-                    var tr_tmp_fragment = document.createDocumentFragment();
-
-                    /**
-                     * Use custom table headers
-                     */
-                    for(var p=0; p<all_table_headers.length; ++p){
-                        // create new header
-                        var th1 = _createNode('th');
-                        var obj = all_table_headers[p];
-                        th1.setAttribute('scope', 'col');
-
-                        // get custom header content
-                        if(obj){
-                            var new_column_key = obj && _getKeys(obj)[0];
-                            th1.textContent = all_table_headers[p][new_column_key];
-                            tr_tmp_fragment.appendChild(th1);
-                        }
-                    }
-
-                    var tr_tmp = _createNode('tr');
-                    tr_tmp.appendChild(tr_tmp_fragment);
-
-                    // create table header & append fragment
-                    var thead = _createNode('thead');
-                    thead.appendChild(tr_tmp);
-
-                    // append header to table
-                    var block_table = _createNode('table');
-                    block_table.appendChild(thead);
-
-                    var tbody_fragment = document.createDocumentFragment();
-
-                    // create table content
-                    for(var n=0; n<cookie_table_data.length; n++){
-                        var tr = _createNode('tr');
-
-                        for(var g=0; g<all_table_headers.length; ++g){
-                            // get custom header content
-                            obj = all_table_headers[g];
-                            if(obj){
-                                new_column_key = _getKeys(obj)[0];
-
-                                var td_tmp = _createNode('td');
-
-                                // Allow html inside table cells
-                                td_tmp.insertAdjacentHTML('beforeend', cookie_table_data[n][new_column_key]);
-                                td_tmp.setAttribute('data-column', obj[new_column_key]);
-
-                                tr.appendChild(td_tmp);
-                            }
-                        }
-
-                        tbody_fragment.appendChild(tr);
-                    }
-
-                    // append tbody_fragment to tbody & append the latter into the table
-                    var tbody = _createNode('tbody');
-                    tbody.appendChild(tbody_fragment);
-                    block_table.appendChild(tbody);
-
-                    block_table_container.appendChild(block_table);
-                }
-
-                /**
-                 * Append only if is either:
-                 * - togglable div with title
-                 * - a simple div with at least a title or description
-                 */
-                if(toggle_data && title_data || (!toggle_data && (title_data || description_data))){
-                    block_section.appendChild(block_table_container);
-
-                    if(new_settings_blocks)
-                        new_settings_blocks.appendChild(block_section);
-                    else
-                        settings_blocks.appendChild(block_section);
-                }
-            }
-
-            // Create settings buttons
-            if(!settings_buttons){
-                settings_buttons = _createNode('div');
-                settings_buttons.id = 's-bns';
-            }
-
-            if(!settings_accept_all_btn){
-                settings_accept_all_btn = _createNode('button');
-                settings_accept_all_btn.id = 's-all-bn';
-                settings_accept_all_btn.className ='c-bn';
-                settings_buttons.appendChild(settings_accept_all_btn);
-
-                _addEvent(settings_accept_all_btn, 'click', function(){
-                    _cookieconsent.hideSettings();
-                    _cookieconsent.hide();
-                    _cookieconsent.accept('all');
-                });
-            }
-
-            settings_accept_all_btn.innerHTML = user_config.languages[lang]['settings_modal']['accept_all_btn'];
-
-            var reject_all_btn_text = user_config.languages[lang]['settings_modal']['reject_all_btn'];
-
-            // Add third [optional] reject all button if provided
-            if(reject_all_btn_text){
-
-                if(!settings_reject_all_btn){
-                    settings_reject_all_btn = _createNode('button');
-                    settings_reject_all_btn.id = 's-rall-bn';
-                    settings_reject_all_btn.className = 'c-bn';
-
-                    _addEvent(settings_reject_all_btn, 'click', function(){
-                        _cookieconsent.hideSettings();
-                        _cookieconsent.hide();
-                        _cookieconsent.accept([]);
-                    });
-
-                    settings_inner.className = "bns-t";
-                    settings_buttons.appendChild(settings_reject_all_btn);
-                }
-
-                settings_reject_all_btn.innerHTML = reject_all_btn_text;
-            }
-
-
-            if(!settings_save_btn){
-                settings_save_btn = _createNode('button');
-                settings_save_btn.id = 's-sv-bn';
-                settings_save_btn.className ='c-bn';
-                settings_buttons.appendChild(settings_save_btn);
-
-                // Add save preferences button onClick event
-                // Hide both settings modal and consent modal
-                _addEvent(settings_save_btn, 'click', function(){
-                    _cookieconsent.hideSettings();
-                    _cookieconsent.hide();
-                    _cookieconsent.accept();
-                });
-            }
-
-            settings_save_btn.innerHTML = user_config.languages[lang]['settings_modal']['save_settings_btn'];
-
-
-            if(new_settings_blocks) {
-                // replace entire existing cookie category blocks with the new cookie categories new blocks (in a different language)
-                settings_inner.replaceChild(new_settings_blocks, settings_blocks);
-                settings_blocks = new_settings_blocks;
-                return;
-            };
-
-            settings_header.appendChild(settings_title);
-            settings_header.appendChild(settings_close_btn_container);
-            settings_inner.appendChild(settings_header);
-            settings_inner.appendChild(settings_blocks);
-            settings_inner.appendChild(settings_buttons);
-            settings_container_inner.appendChild(settings_inner);
-
-            settings.appendChild(settings_container_inner);
-            settings_container_valign.appendChild(settings);
-            settings_container.appendChild(settings_container_valign);
-
-            all_modals_container.appendChild(settings_container);
-            all_modals_container.appendChild(overlay);
-        }
-
-        /**
-         * Generate cookie consent html markup
-         */
-        var _createCookieConsentHTML = function(){
-
-            // Create main container which holds both consent modal & settings modal
-            main_container = _createNode('div');
-            main_container.id = 'cc--main';
-
-            // Fix layout flash
-            main_container.style.position = "fixed";
-            main_container.style.zIndex = "1000000";
-            main_container.innerHTML = '<!--[if lt IE 9 ]><div id="cc_div" class="cc_div ie"></div><![endif]--><!--[if (gt IE 8)|!(IE)]><!--><div id="cc_div" class="cc_div"></div><!--<![endif]-->'
-            all_modals_container = main_container.children[0];
-
-            // Get current language
-            var lang = _config.current_lang;
-
-            // Create consent modal
-            if(consent_modal_exists)
-                _createConsentModal(lang);
-
-            // Always create settings modal
-            _createSettingsModal(lang);
-
-            // Finally append everything (main_container holds both modals)
-            (root || document.body).appendChild(main_container);
-        }
-
-        /**
-         * Update/change modals language
-         * @param {String} lang new language
-         * @param {Boolean} [force] update language fields forcefully
-         * @returns {Boolean}
-         */
-        _cookieconsent.updateLanguage = function(lang, force){
-
-            if(typeof lang !== 'string') return;
-
-            /**
-             * Validate language to avoid errors
-             */
-            var new_validated_lang = _getValidatedLanguage(lang, user_config.languages);
-
-            /**
-             * Set language only if it differs from current
-             */
-            if(new_validated_lang !== _config.current_lang || force === true){
-                _config.current_lang = new_validated_lang;
-
-                if(consent_modal_exists){
-                    _createConsentModal(new_validated_lang);
-                    _addDataButtonListeners(consent_modal_inner);
-                }
-
-                _createSettingsModal(new_validated_lang);
-
-                _log("CookieConsent [LANGUAGE]: curr_lang: '" + new_validated_lang + "'");
-
-                return true;
-            }
-
-            return false;
-        }
-
-        /**
-         * Delete all cookies which are unused (based on selected preferences)
-         *
-         * @param {boolean} [clearOnFirstAction]
-         */
-        var _autoclearCookies = function(clearOnFirstAction){
-
-            // Get number of blocks
-            var len = all_blocks.length;
-            var count = -1;
-
-            // reset reload state
-            reload_page = false;
-
-            // Retrieve all cookies
-            var all_cookies_array = _getCookie('', 'all');
-
-            // delete cookies on 'www.domain.com' and '.www.domain.com' (can also be without www)
-            var domains = [_config.cookie_domain, '.'+_config.cookie_domain];
-
-            // if domain has www, delete cookies also for 'domain.com' and '.domain.com'
-            if(_config.cookie_domain.slice(0, 4) === 'www.'){
-                var non_www_domain = _config.cookie_domain.substr(4);  // remove first 4 chars (www.)
-                domains.push(non_www_domain);
-                domains.push('.' + non_www_domain);
-            }
-
-            // For each block
-            for(var i=0; i<len; i++){
-
-                // Save current block (local scope & less accesses -> ~faster value retrieval)
-                var curr_block = all_blocks[i];
-
-                // If current block has a toggle for opt in/out
-                if(Object.prototype.hasOwnProperty.call(curr_block, "toggle")){
-
-                    // if current block has a cookie table, an off toggle,
-                    // and its preferences were just changed => delete cookies
-                    var category_just_disabled = _inArray(changed_settings, curr_block['toggle']['value']) > -1;
-                    if(
-                        !toggle_states[++count] &&
-                        Object.prototype.hasOwnProperty.call(curr_block, "cookie_table") &&
-                        (clearOnFirstAction || category_just_disabled)
-                    ){
-                        var curr_cookie_table = curr_block['cookie_table'];
-
-                        // Get first property name
-                        var ckey = _getKeys(all_table_headers[0])[0];
-
-                        // Get number of cookies defined in cookie_table
-                        var clen = curr_cookie_table.length;
-
-                        // set "reload_page" to true if reload=on_disable
-                        if(curr_block['toggle']['reload'] === 'on_disable')
-                            category_just_disabled && (reload_page = true);
-
-                        // for each row defined in the cookie table
-                        for(var j=0; j<clen; j++){
-
-                            // Get current row of table (corresponds to all cookie params)
-                            var curr_row = curr_cookie_table[j], found_cookies = [];
-                            var curr_cookie_name = curr_row[ckey];
-                            var is_regex = curr_row['is_regex'] || false;
-                            var curr_cookie_domain = curr_row['domain'] || null;
-                            var curr_cookie_path = curr_row['path'] || false;
-
-                            // set domain to the specified domain
-                            curr_cookie_domain && ( domains = [curr_cookie_domain, '.'+curr_cookie_domain]);
-
-                            // If regex provided => filter cookie array
-                            if(is_regex){
-                                for(var n=0; n<all_cookies_array.length; n++){
-                                    if(all_cookies_array[n].match(curr_cookie_name)){
-                                        found_cookies.push(all_cookies_array[n]);
-                                    }
-                                }
-                            }else{
-                                var found_index = _inArray(all_cookies_array, curr_cookie_name);
-                                if(found_index > -1) found_cookies.push(all_cookies_array[found_index]);
-                            }
-
-                            _log("CookieConsent [AUTOCLEAR]: search cookie: '" + curr_cookie_name + "', found:", found_cookies);
-
-                            // If cookie exists -> delete it
-                            if(found_cookies.length > 0){
-                                _eraseCookies(found_cookies, curr_cookie_path, domains);
-                                curr_block['toggle']['reload'] === 'on_clear' && (reload_page = true);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        /**
-         * Set toggles/checkboxes based on accepted categories and save cookie
-         * @param {string[]} accepted_categories - Array of categories to accept
-         */
-        var _saveCookiePreferences = function(accepted_categories){
-
-            changed_settings = [];
-
-            // Retrieve all toggle/checkbox values
-            var category_toggles = document.querySelectorAll('.c-tgl') || [];
-
-            // If there are opt in/out toggles ...
-            if(category_toggles.length > 0){
-
-                for(var i=0; i<category_toggles.length; i++){
-                    if(_inArray(accepted_categories, all_categories[i]) !== -1){
-                        category_toggles[i].checked = true;
-                        if(!toggle_states[i]){
-                            changed_settings.push(all_categories[i]);
-                            toggle_states[i] = true;
-                        }
-                    }else{
-                        category_toggles[i].checked = false;
-                        if(toggle_states[i]){
-                            changed_settings.push(all_categories[i]);
-                            toggle_states[i] = false;
-                        }
-                    }
-                }
-            }
-
-            /**
-             * Clear cookies when settings/preferences change
-             */
-            if(!invalid_consent && _config.autoclear_cookies && changed_settings.length > 0)
-                _autoclearCookies();
-
-            if(!consent_date) consent_date = new Date();
-            if(!consent_uuid) consent_uuid = _uuidv4();
-
-            saved_cookie_content = {
-                "categories": accepted_categories,
-                "revision": _config.revision,
-                "data": cookie_data,
-                "rfc_cookie": _config.use_rfc_cookie,
-                "consent_date": consent_date.toISOString(),
-                "consent_uuid": consent_uuid
-            }
-
-            // save cookie with preferences 'categories' (only if never accepted or settings were updated)
-            if(invalid_consent || changed_settings.length > 0){
-                valid_revision = true;
-
-                /**
-                 * Update "last_consent_update" only if it is invalid (after t)
-                 */
-                if(!last_consent_update)
-                    last_consent_update = consent_date;
-                else
-                    last_consent_update = new Date();
-
-                saved_cookie_content['last_consent_update'] = last_consent_update.toISOString();
-
-                /**
-                 * Update accept type
-                 */
-                accept_type = _getAcceptType(_getCurrentCategoriesState());
-
-                _setCookie(_config.cookie_name, JSON.stringify(saved_cookie_content));
-                _manageExistingScripts();
-
-                //_printConsentDateHTML();
-            }
-
-            if(invalid_consent){
-
-                /**
-                 * Delete unused/"zombie" cookies if consent is not valid (not yet expressed or cookie has expired)
-                 */
-                if(_config.autoclear_cookies)
-                    _autoclearCookies(true);
-
-                if(typeof onFirstAction === 'function')
-                    onFirstAction(_cookieconsent.getUserPreferences(), saved_cookie_content);
-
-                if(typeof onAccept === 'function')
-                    onAccept(saved_cookie_content);
-
-                /**
-                 * Set consent as valid
-                 */
-                invalid_consent = false;
-
-                if(_config.mode === 'opt-in') return;
-            }
-
-            // fire onChange only if settings were changed
-            if(typeof onChange === "function" && changed_settings.length > 0)
-                onChange(saved_cookie_content, changed_settings);
-
-            /**
-             * reload page if needed
-             */
-            if(reload_page)
-                window.location.reload();
-        }
-
-        /**
-         * Returns index of found element inside array, otherwise -1
-         * @param {Array} arr
-         * @param {Object} value
-         * @returns {number}
-         */
-        var _inArray = function(arr, value){
-            return arr.indexOf(value);
-        }
-
-        /**
-         * Helper function which prints info (console.log())
-         * @param {Object} print_msg
-         * @param {Object} [optional_param]
-         */
-        var _log = function(print_msg, optional_param, error){
-            ENABLE_LOGS && (!error ? console.log(print_msg, optional_param !== undefined ? optional_param : ' ') : console.error(print_msg, optional_param || ""));
-        }
-
-        /**
-         * Helper function which creates an HTMLElement object based on 'type' and returns it.
-         * @param {string} type
-         * @returns {HTMLElement}
-         */
-        var _createNode = function(type){
-            var el = document.createElement(type);
-            if(type === 'button'){
-                el.setAttribute('type', type);
-            }
-            return el;
-        }
-
-        /**
-         * Generate RFC4122-compliant UUIDs.
-         * https://stackoverflow.com/questions/105034/how-to-create-a-guid-uuid?page=1&tab=votes#tab-top
-         * @returns {string}
-         */
-        var _uuidv4 = function(){
-            return ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, function(c){
-                return (c ^ (window.crypto || window.msCrypto).getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
-            });
-        }
-
-        /**
-         * Resolve which language should be used.
-         *
-         * @param {Object} languages Object with language translations
-         * @param {string} [requested_language] Language specified by given configuration parameters
-         * @returns {string}
-         */
-        var _resolveCurrentLang = function (languages, requested_language) {
-
-            if (_config.auto_language === 'browser') {
-                return _getValidatedLanguage(_getBrowserLang(), languages);
-            } else if (_config.auto_language === 'document') {
-                return _getValidatedLanguage(document.documentElement.lang, languages);
-            } else {
-                if (typeof requested_language === 'string') {
-                    return _config.current_lang = _getValidatedLanguage(requested_language, languages);
-                }
-            }
-
-            _log("CookieConsent [LANG]: setting current_lang = '" + _config.current_lang + "'");
-            return _config.current_lang; // otherwise return default
-        }
-
-        /**
-         * Get current client's browser language
-         * @returns {string}
-         */
-        var _getBrowserLang = function(){
-            var browser_lang = navigator.language || navigator.browserLanguage;
-            browser_lang.length > 2 && (browser_lang = browser_lang[0]+browser_lang[1]);
-            _log("CookieConsent [LANG]: detected_browser_lang = '"+ browser_lang + "'");
-            return browser_lang.toLowerCase()
-        }
-
-        /**
-         * Trap focus inside modal and focus the first
-         * focusable element of current active modal
-         */
-        var _handleFocusTrap = function(){
-            var tabbedOutsideDiv = false;
-            var tabbedInsideModal = false;
-
-            _addEvent(document, 'keydown', function(e){
-                e = e || window.event;
-
-                // If is tab key => ok
-                if(e.key !== 'Tab') return;
-
-                // If there is any modal to focus
-                if(current_modal_focusable){
-                    // If reached natural end of the tab sequence => restart
-                    if(e.shiftKey){
-                        if (document.activeElement === current_modal_focusable[0]) {
-                            current_modal_focusable[1].focus();
-                            e.preventDefault();
-                        }
-                    }else{
-                        if (document.activeElement === current_modal_focusable[1]) {
-                            current_modal_focusable[0].focus();
-                            e.preventDefault();
-                        }
-                    }
-
-                    // If have not yet used tab (or shift+tab) and modal is open ...
-                    // Focus the first focusable element
-                    if(!tabbedInsideModal && !clicked_inside_modal){
-                        tabbedInsideModal = true;
-                        !tabbedOutsideDiv && e.preventDefault();
-
-                        if(e.shiftKey){
-                            if(current_modal_focusable[3]){
-                                if(!current_modal_focusable[2]){
-                                    current_modal_focusable[0].focus();
-                                }else{
-                                    current_modal_focusable[2].focus();
-                                }
-                            }else{
-                                current_modal_focusable[1].focus();
-                            }
-                        }else{
-                            if(current_modal_focusable[3]){
-                                current_modal_focusable[3].focus();
-                            }else{
-                                current_modal_focusable[0].focus();
-                            }
-                        }
-                    }
-                }
-
-                !tabbedInsideModal && (tabbedOutsideDiv = true);
-            });
-
-            if(document.contains){
-                _addEvent(main_container, 'click', function(e){
-                    e = e || window.event;
-                    /**
-                     * If click is on the foreground overlay (and not inside settings_modal),
-                     * hide settings modal
-                     *
-                     * Notice: click on div is not supported in IE
-                     */
-                    if(settings_modal_visible){
-                        if(!settings_inner.contains(e.target)){
-                            _cookieconsent.hideSettings(0);
-                            clicked_inside_modal = false;
-                        }else{
-                            clicked_inside_modal = true;
-                        }
-                    }else if(consent_modal_visible){
-                        if(consent_modal.contains(e.target)){
-                            clicked_inside_modal = true;
-                        }
-                    }
-
-                }, true);
-            }
-        }
-
-        /**
-         * Manage each modal's layout
-         * @param {Object} gui_options
-         */
-        var _guiManager = function(gui_options, only_consent_modal){
-
-            // If gui_options is not object => exit
-            if(typeof gui_options !== 'object') return;
-
-            var consent_modal_options = gui_options['consent_modal'];
-            var settings_modal_options = gui_options['settings_modal'];
-
-            /**
-             * Helper function which adds layout and
-             * position classes to given modal
-             *
-             * @param {HTMLElement} modal
-             * @param {string[]} allowed_layouts
-             * @param {string[]} allowed_positions
-             * @param {string} layout
-             * @param {string[]} position
-             */
-            function _setLayout(modal, allowed_layouts, allowed_positions, allowed_transitions, layout, position, transition){
-                position = (position && position.split(" ")) || [];
-
-                // Check if specified layout is valid
-                if(_inArray(allowed_layouts, layout) > -1){
-
-                    // Add layout classes
-                    _addClass(modal, layout);
-
-                    // Add position class (if specified)
-                    if(!(layout === 'bar' && position[0] === 'middle') && _inArray(allowed_positions, position[0]) > -1){
-                        for(var i=0; i<position.length; i++){
-                            _addClass(modal, position[i]);
-                        }
-                    }
-                }
-
-                // Add transition class
-                (_inArray(allowed_transitions, transition) > -1) && _addClass(modal, transition);
-            }
-
-            if(consent_modal_exists && consent_modal_options){
-                _setLayout(
-                    consent_modal,
-                    ['box', 'bar', 'cloud'],
-                    ['top', 'middle', 'bottom'],
-                    ['zoom', 'slide'],
-                    consent_modal_options['layout'],
-                    consent_modal_options['position'],
-                    consent_modal_options['transition']
-                );
-            }
-
-            if(!only_consent_modal && settings_modal_options){
-                _setLayout(
-                    settings_container,
-                    ['bar'],
-                    ['left', 'right'],
-                    ['zoom', 'slide'],
-                    settings_modal_options['layout'],
-                    settings_modal_options['position'],
-                    settings_modal_options['transition']
-                );
-            }
-        }
-
-        /**
-         * Returns true if cookie category is accepted by the user
-         * @param {string} cookie_category
-         * @returns {boolean}
-         */
-        _cookieconsent.allowedCategory = function(cookie_category){
-
-            if(!invalid_consent || _config.mode === 'opt-in')
-                var allowed_categories = JSON.parse(_getCookie(_config.cookie_name, 'one', true) || '{}')['categories'] || []
-            else  // mode is 'opt-out'
-                var allowed_categories = default_enabled_categories;
-
-            return _inArray(allowed_categories, cookie_category) > -1;
-        }
-
-        /**
-         * "Init" method. Will run once and only if modals do not exist
-         */
-        _cookieconsent.run = function(user_config){
-            if(!document.getElementById('cc_div')){
-
-                // configure all parameters
-                _setConfig(user_config);
-
-                // if is bot, don't run plugin
-                if(is_bot) return;
-
-                // Retrieve cookie value (if set)
-                saved_cookie_content = JSON.parse(_getCookie(_config.cookie_name, 'one', true) || "{}");
-
-                // Retrieve "consent_uuid"
-                consent_uuid = saved_cookie_content['consent_uuid'];
-
-                // If "consent_uuid" is present => assume that consent was previously given
-                var cookie_consent_accepted = consent_uuid !== undefined;
-
-                // Retrieve "consent_date"
-                consent_date = saved_cookie_content['consent_date'];
-                consent_date && (consent_date = new Date(consent_date));
-
-                // Retrieve "last_consent_update"
-                last_consent_update = saved_cookie_content['last_consent_update'];
-                last_consent_update && (last_consent_update = new Date(last_consent_update));
-
-                // Retrieve "data"
-                cookie_data = saved_cookie_content['data'] !== undefined ? saved_cookie_content['data'] : null;
-
-                // If revision is enabled and current value !== saved value inside the cookie => revision is not valid
-                if(revision_enabled && saved_cookie_content['revision'] !== _config.revision){
-                    valid_revision = false;
-                }
-
-                // If consent is not valid => create consent modal
-                consent_modal_exists = invalid_consent = (!cookie_consent_accepted || !valid_revision || !consent_date || !last_consent_update || !consent_uuid);
-
-                // Generate cookie-settings dom (& consent modal)
-                _createCookieConsentHTML();
-
-                _getModalFocusableData();
-                _guiManager(user_config['gui_options']);
-                _addDataButtonListeners();
-
-                if(_config.autorun && consent_modal_exists){
-                    _cookieconsent.show(user_config['delay'] || 0);
-                }
-
-                // Add class to enable animations/transitions
-                setTimeout(function(){_addClass(main_container, 'c--anim');}, 30);
-
-                // Accessibility :=> if tab pressed => trap focus inside modal
-                setTimeout(function(){_handleFocusTrap();}, 100);
-
-                // If consent is valid
-                if(!invalid_consent){
-                    var rfc_prop_exists = typeof saved_cookie_content['rfc_cookie'] === "boolean";
-
-                    /*
-                     * Convert cookie to rfc format (if `use_rfc_cookie` is enabled)
-                     */
-                    if(!rfc_prop_exists || (rfc_prop_exists && saved_cookie_content['rfc_cookie'] !== _config.use_rfc_cookie)){
-                        saved_cookie_content['rfc_cookie'] = _config.use_rfc_cookie;
-                        _setCookie(_config.cookie_name, JSON.stringify(saved_cookie_content));
-                    }
-
-                    /**
-                     * Update accept type
-                     */
-                    accept_type = _getAcceptType(_getCurrentCategoriesState());
-
-                    _manageExistingScripts();
-
-                    if(typeof onAccept === 'function')
-                        onAccept(saved_cookie_content);
-
-                    _log("CookieConsent [NOTICE]: consent already given!", saved_cookie_content);
-
-                }else{
-                    if(_config.mode === 'opt-out'){
-                        _log("CookieConsent [CONFIG] mode='" + _config.mode + "', default enabled categories:", default_enabled_categories);
-                        _manageExistingScripts(default_enabled_categories);
-                    }
-                    _log("CookieConsent [NOTICE]: ask for consent!");
-                }
-            }else{
-                _log("CookieConsent [NOTICE]: cookie consent already attached to body!");
-            }
-        }
-
-        /**
-         * Show settings modal (with optional delay)
-         * @param {number} delay
-         */
-        _cookieconsent.showSettings = function(delay){
-            setTimeout(function() {
-                _addClass(html_dom, "show--settings");
-                settings_container.setAttribute('aria-hidden', 'false');
-                settings_modal_visible = true;
-
-                /**
-                 * Set focus to the first focusable element inside settings modal
-                 */
-                setTimeout(function(){
-                    // If there is no consent-modal, keep track of the last focused elem.
-                    if(!consent_modal_visible){
-                        last_elem_before_modal = document.activeElement;
-                    }else{
-                        last_consent_modal_btn_focus = document.activeElement;
-                    }
-
-                    if (settings_modal_focusable.length === 0) return;
-
-                    if(settings_modal_focusable[3]){
-                        settings_modal_focusable[3].focus();
-                    }else{
-                        settings_modal_focusable[0].focus();
-                    }
-                    current_modal_focusable = settings_modal_focusable;
-                }, 200);
-
-                _log("CookieConsent [SETTINGS]: show settings_modal");
-            }, delay > 0 ? delay : 0);
-        }
-
-        /**
-         * This function handles the loading/activation logic of the already
-         * existing scripts based on the current accepted cookie categories
-         *
-         * @param {string[]} [must_enable_categories]
-         */
-        var _manageExistingScripts = function(must_enable_categories){
-
-            if(!_config.page_scripts) return;
-
-            // get all the scripts with "cookie-category" attribute
-            var scripts = document.querySelectorAll('script[' + _config.script_selector + ']');
-            var accepted_categories = must_enable_categories || saved_cookie_content['categories'] || [];
-
-            /**
-             * Load scripts (sequentially), using a recursive function
-             * which loops through the scripts array
-             * @param {Element[]} scripts scripts to load
-             * @param {number} index current script to load
-             */
-            var _loadScripts = function(scripts, index){
-                if(index < scripts.length){
-
-                    var curr_script = scripts[index];
-                    var curr_script_category = curr_script.getAttribute(_config.script_selector);
-
-                    /**
-                     * If current script's category is on the array of categories
-                     * accepted by the user => load script
-                     */
-                    if(_inArray(accepted_categories, curr_script_category) > -1){
-
-                        curr_script.type = 'text/javascript';
-                        curr_script.removeAttribute(_config.script_selector);
-
-                        // get current script data-src
-                        var src = curr_script.getAttribute('data-src');
-
-                        // some scripts (like ga) might throw warning if data-src is present
-                        src && curr_script.removeAttribute('data-src');
-
-                        // create fresh script (with the same code)
-                        var fresh_script = _createNode('script');
-                        fresh_script.textContent = curr_script.innerHTML;
-
-                        // Copy attributes over to the new "revived" script
-                        (function(destination, source){
-                            var attributes = source.attributes;
-                            var len = attributes.length;
-                            for(var i=0; i<len; i++){
-                                var attr_name = attributes[i].nodeName;
-                                destination.setAttribute(attr_name , source[attr_name] || source.getAttribute(attr_name));
-                            }
-                        })(fresh_script, curr_script);
-
-                        // set src (if data-src found)
-                        src ? (fresh_script.src = src) : (src = curr_script.src);
-
-                        // if script has "src" attribute
-                        // try loading it sequentially
-                        if(src){
-                            // load script sequentially => the next script will not be loaded
-                            // until the current's script onload event triggers
-                            if(fresh_script.readyState) {  // only required for IE <9
-                                fresh_script.onreadystatechange = function() {
-                                    if (fresh_script.readyState === "loaded" || fresh_script.readyState === "complete" ) {
-                                        fresh_script.onreadystatechange = null;
-                                        _loadScripts(scripts, ++index);
-                                    }
-                                };
-                            }else{  // others
-                                fresh_script.onload = function(){
-                                    fresh_script.onload = null;
-                                    _loadScripts(scripts, ++index);
-                                };
-                            }
-                        }
-
-                        // Replace current "sleeping" script with the new "revived" one
-                        curr_script.parentNode.replaceChild(fresh_script, curr_script);
-
-                        /**
-                         * If we managed to get here and scr is still set, it means that
-                         * the script is loading/loaded sequentially so don't go any further
-                         */
-                        if(src) return;
-                    }
-
-                    // Go to next script right away
-                    _loadScripts(scripts, ++index);
-                }
-            }
-
-            _loadScripts(scripts, 0);
-        }
-
-        /**
-         * Save custom data inside cookie
-         * @param {object|string} new_data
-         * @param {string} [mode]
-         * @returns {boolean}
-         */
-        var _setCookieData = function(new_data, mode){
-
-            var set = false;
-            /**
-             * If mode is 'update':
-             * add/update only the specified props.
-             */
-            if(mode === 'update'){
-                cookie_data = _cookieconsent.get('data');
-                var same_type = typeof cookie_data === typeof new_data;
-
-                if(same_type && typeof cookie_data === "object"){
-                    !cookie_data && (cookie_data = {});
-
-                    for(var prop in new_data){
-                        if(cookie_data[prop] !== new_data[prop]){
-                            cookie_data[prop] = new_data[prop]
-                            set = true;
-                        }
-                    }
-                }else if((same_type || !cookie_data) && cookie_data !== new_data){
-                    cookie_data = new_data;
-                    set = true;
-                }
-            }else{
-                cookie_data = new_data;
-                set = true;
-            }
-
-            if(set){
-                saved_cookie_content['data'] = cookie_data;
-                _setCookie(_config.cookie_name, JSON.stringify(saved_cookie_content));
-            }
-
-            return set;
-        }
-
-        /**
-         * Helper method to set a variety of fields
-         * @param {string} field
-         * @param {object} data
-         * @returns {boolean}
-         */
-        _cookieconsent.set = function(field, data){
-            switch(field){
-                case 'data': return _setCookieData(data['value'], data['mode']);
-                default: return false;
-            }
-        }
-
-        /**
-         * Retrieve data from existing cookie
-         * @param {string} field
-         * @param {string} [cookie_name]
-         * @returns {any}
-         */
-        _cookieconsent.get = function(field, cookie_name){
-            var cookie = JSON.parse(_getCookie(cookie_name || _config.cookie_name, 'one', true) || "{}");
-
-            return cookie[field];
-        }
-
-        /**
-         * Read current configuration value
-         * @returns {any}
-         */
-        _cookieconsent.getConfig = function(field){
-            return _config[field] || user_config[field];
-        }
-
-        /**
-         * Obtain accepted and rejected categories
-         * @returns {{accepted: string[], rejected: string[]}}
-         */
-        var _getCurrentCategoriesState = function(){
-
-            // get accepted categories
-            accepted_categories = saved_cookie_content['categories'] || [];
-
-            // calculate rejected categories (all_categories - accepted_categories)
-            rejected_categories = all_categories.filter(function(category){
-                return (_inArray(accepted_categories, category) === -1);
-            });
-
-            return {
-                accepted: accepted_categories,
-                rejected: rejected_categories
-            }
-        }
-
-        /**
-         * Calculate "accept type" given current categories state
-         * @param {{accepted: string[], rejected: string[]}} currentCategoriesState
-         * @returns {string}
-         */
-        var _getAcceptType = function(currentCategoriesState){
-
-            var type = 'custom';
-
-            // number of categories marked as necessary/readonly
-            var necessary_categories_length = readonly_categories.filter(function(readonly){
-                return readonly === true;
-            }).length;
-
-            // calculate accept type based on accepted/rejected categories
-            if(currentCategoriesState.accepted.length === all_categories.length)
-                type = 'all';
-            else if(currentCategoriesState.accepted.length === necessary_categories_length)
-                type = 'necessary'
-
-            return type;
-        }
-
-        /**
-         * @typedef {object} userPreferences
-         * @property {string} accept_type
-         * @property {string[]} accepted_categories
-         * @property {string[]} rejected_categories
-         */
-
-        /**
-         * Retrieve current user preferences (summary)
-         * @returns {userPreferences}
-         */
-        _cookieconsent.getUserPreferences = function(){
-            var currentCategoriesState = _getCurrentCategoriesState();
-            var accept_type = _getAcceptType(currentCategoriesState);
-
-            return {
-                'accept_type': accept_type,
-                'accepted_categories': currentCategoriesState.accepted,
-                'rejected_categories': currentCategoriesState.rejected
-            }
-        }
-
-        /**
-         * Function which will run after script load
-         * @callback scriptLoaded
-         */
-
-        /**
-         * Dynamically load script (append to head)
-         * @param {string} src
-         * @param {scriptLoaded} callback
-         * @param {object[]} [attrs] Custom attributes
-         */
-        _cookieconsent.loadScript = function(src, callback, attrs){
-
-            var function_defined = typeof callback === 'function';
-
-            // Load script only if not already loaded
-            if(!document.querySelector('script[src="' + src + '"]')){
-
-                var script = _createNode('script');
-
-                // if an array is provided => add custom attributes
-                if(attrs && attrs.length > 0){
-                    for(var i=0; i<attrs.length; ++i){
-                        attrs[i] && script.setAttribute(attrs[i]['name'], attrs[i]['value']);
-                    }
-                }
-
-                // if callback function defined => run callback onload
-                if(function_defined){
-                    script.onload = callback;
-                }
-
-                script.src = src;
-
-                /**
-                 * Append script to head
-                 */
-                document.head.appendChild(script);
-            }else{
-                function_defined && callback();
-            }
-        }
-
-        /**
-         * Manage dynamically loaded scripts: https://github.com/orestbida/cookieconsent/issues/101
-         * If plugin has already run, call this method to enable
-         * the newly added scripts based on currently selected preferences
-         */
-        _cookieconsent.updateScripts = function(){
-            _manageExistingScripts();
-        }
-
-        /**
-         * Show cookie consent modal (with delay parameter)
-         * @param {number} [delay]
-         * @param {boolean} [create_modal] create modal if it doesn't exist
-         */
-        _cookieconsent.show = function(delay, create_modal){
-
-            if(create_modal === true)
-                _createConsentModal(_config.current_lang);
-
-            if(consent_modal_exists){
-                setTimeout(function() {
-                    _addClass(html_dom, "show--consent");
-
-                    /**
-                     * Update attributes/internal statuses
-                     */
-                    consent_modal.setAttribute('aria-hidden', 'false');
-                    consent_modal_visible = true;
-
-                    setTimeout(function(){
-                        last_elem_before_modal = document.activeElement;
-                        current_modal_focusable = consent_modal_focusable;
-                    }, 200);
-
-                    _log("CookieConsent [MODAL]: show consent_modal");
-                }, delay > 0 ? delay : (create_modal ? 30 : 0));
-            }
-        }
-
-        /**
-         * Hide consent modal
-         */
-        _cookieconsent.hide = function(){
-            if(consent_modal_exists){
-                _removeClass(html_dom, "show--consent");
-                consent_modal.setAttribute('aria-hidden', 'true');
-                consent_modal_visible = false;
-
-                setTimeout(function(){
-                    //restore focus to the last page element which had focus before modal opening
-                    last_elem_before_modal.focus();
-                    current_modal_focusable = null;
-                }, 200);
-
-                _log("CookieConsent [MODAL]: hide");
-            }
-        }
-
-        /**
-         * Hide settings modal
-         */
-        _cookieconsent.hideSettings = function(){
-            _removeClass(html_dom, "show--settings");
-            settings_modal_visible = false;
-            settings_container.setAttribute('aria-hidden', 'true');
-
-
-            setTimeout(function(){
-                /**
-                 * If consent modal is visible, focus him (instead of page document)
-                 */
-                if(consent_modal_visible){
-                    last_consent_modal_btn_focus && last_consent_modal_btn_focus.focus();
-                    current_modal_focusable = consent_modal_focusable;
-                }else{
-                    /**
-                     * Restore focus to last page element which had focus before modal opening
-                     */
-                    last_elem_before_modal && last_elem_before_modal.focus();
-                    current_modal_focusable = null;
-                }
-
-                clicked_inside_modal = false;
-            }, 200);
-
-            _log("CookieConsent [SETTINGS]: hide settings_modal");
-        }
-
-        /**
-         * Accept cookieconsent function API
-         * @param {string[]|string} _categories - Categories to accept
-         * @param {string[]} [_exclusions] - Excluded categories [optional]
-         */
-        _cookieconsent.accept = function(_categories, _exclusions){
-            var categories = _categories || undefined;
-            var exclusions = _exclusions || [];
-            var to_accept = [];
-
-            /**
-             * Get all accepted categories
-             * @returns {string[]}
-             */
-            var _getCurrentPreferences = function(){
-                var toggles = document.querySelectorAll('.c-tgl') || [];
-                var states = [];
-
-                for(var i=0; i<toggles.length; i++){
-                    if(toggles[i].checked){
-                        states.push(toggles[i].value);
-                    }
-                }
-                return states;
-            }
-
-            if(!categories){
-                to_accept = _getCurrentPreferences();
-            }else{
-                if(
-                    typeof categories === "object" &&
-                    typeof categories.length === "number"
-                ){
-                    for(var i=0; i<categories.length; i++){
-                        if(_inArray(all_categories, categories[i]) !== -1)
-                            to_accept.push(categories[i]);
-                    }
-                }else if(typeof categories === "string"){
-                    if(categories === 'all')
-                        to_accept = all_categories.slice();
-                    else{
-                        if(_inArray(all_categories, categories) !== -1)
-                            to_accept.push(categories);
-                    }
-                }
-            }
-
-            // Remove excluded categories
-            if(exclusions.length >= 1){
-                for(i=0; i<exclusions.length; i++){
-                    to_accept = to_accept.filter(function(item) {
-                        return item !== exclusions[i]
-                    })
-                }
-            }
-
-            // Add back all the categories set as "readonly/required"
-            for(i=0; i<all_categories.length; i++){
-                if(
-                    readonly_categories[i] === true &&
-                    _inArray(to_accept, all_categories[i]) === -1
-                ){
-                    to_accept.push(all_categories[i]);
-                }
-            }
-
-            _saveCookiePreferences(to_accept);
-        }
-
-        /**
-         * API function to easily erase cookies
-         * @param {(string|string[])} _cookies
-         * @param {string} [_path] - optional
-         * @param {string} [_domain] - optional
-         */
-        _cookieconsent.eraseCookies = function(_cookies, _path, _domain){
-            var cookies = [];
-            var domains = _domain
-                ? [_domain, "."+_domain]
-                : [_config.cookie_domain, "."+_config.cookie_domain];
-
-            if(typeof _cookies === "object" && _cookies.length > 0){
-                for(var i=0; i<_cookies.length; i++){
-                    this.validCookie(_cookies[i]) && cookies.push(_cookies[i]);
-                }
-            }else{
-                this.validCookie(_cookies) && cookies.push(_cookies);
-            }
-
-            _eraseCookies(cookies, _path, domains);
-        }
-
-        /**
-         * Set cookie, by specifying name and value
-         * @param {string} name
-         * @param {string} value
-         */
-        var _setCookie = function(name, value) {
-
-            var cookie_expiration = _config.cookie_expiration;
-
-            if(typeof _config.cookie_necessary_only_expiration === 'number' && accept_type === 'necessary')
-                cookie_expiration = _config.cookie_necessary_only_expiration;
-
-            value = _config.use_rfc_cookie ? encodeURIComponent(value) : value;
-
-            var date = new Date();
-            date.setTime(date.getTime() + (1000 * (cookie_expiration * 24 * 60 * 60)));
-            var expires = "; expires=" + date.toUTCString();
-
-            var cookieStr = name + "=" + (value || "") + expires + "; Path=" + _config.cookie_path + ";";
-            cookieStr += " SameSite=" + _config.cookie_same_site + ";";
-
-            // assures cookie works with localhost (=> don't specify domain if on localhost)
-            if(window.location.hostname.indexOf(".") > -1){
-                cookieStr += " Domain=" + _config.cookie_domain + ";";
-            }
-
-            if(window.location.protocol === "https:") {
-                cookieStr += " Secure;";
-            }
-
-            document.cookie = cookieStr;
-
-            _log("CookieConsent [SET_COOKIE]: cookie '" + name + "'=", JSON.parse(value));
-            _log("CookieConsent [SET_COOKIE]: '" + name + "' expires after " + cookie_expiration + " day(s)");
-        }
-
-        /**
-         * Get cookie value by name,
-         * returns the cookie value if found (or an array
-         * of cookies if filter provided), otherwise empty string: ""
-         * @param {string} name
-         * @param {string} filter 'one' or 'all'
-         * @param {boolean} [get_value] set to true to obtain its value
-         * @returns {string|string[]}
-         */
-        var _getCookie = function(name, filter, get_value) {
-            var found;
-
-            if(filter === 'one'){
-                found = document.cookie.match("(^|;)\\s*" + name + "\\s*=\\s*([^;]+)");
-                found = found ? (get_value ? found.pop() : name) : "";
-
-                if(found && name === _config.cookie_name){
-                    try{
-                        found = JSON.parse(found)
-                    }catch(e){
-                        try {
-                            found = JSON.parse(decodeURIComponent(found))
-                        } catch (e) {
-                            // if I got here => cookie value is not a valid json string
-                            found = {};
-                        }
-                    }
-                    found = JSON.stringify(found);
-                }
-            }else if(filter === 'all'){
-                // array of names of all existing cookies
-                var cookies = document.cookie.split(/;\s*/); found = [];
-                for(var i=0; i<cookies.length; i++){
-                    found.push(cookies[i].split("=")[0]);
-                }
-            }
-
-            return found;
-        }
-
-        /**
-         * Delete cookie by name & path
-         * @param {string[]} cookies
-         * @param {string} [custom_path] - optional
-         * @param {string[]} domains - example: ['domain.com', '.domain.com']
-         */
-        var _eraseCookies = function(cookies, custom_path, domains) {
-            var path = custom_path ? custom_path : '/';
-            var expires = 'Expires=Thu, 01 Jan 1970 00:00:01 GMT;';
-
-            for(var i=0; i<cookies.length; i++){
-                for(var j=0; j<domains.length; j++){
-                    document.cookie = cookies[i] + '=; path=' + path +
-                    (domains[j].indexOf('.') > -1 ? '; domain=' + domains[j] : "") + '; ' + expires;
-                }
-                _log("CookieConsent [AUTOCLEAR]: deleting cookie: '" + cookies[i] + "' path: '" + path + "' domain:", domains);
-            }
-        }
-
-        /**
-         * Returns true if cookie was found and has valid value (not empty string)
-         * @param {string} cookie_name
-         * @returns {boolean}
-         */
-        _cookieconsent.validCookie = function(cookie_name){
-            return _getCookie(cookie_name, 'one', true) !== "";
-        }
-
-        /**
-         * Function to run when event is fired
-         * @callback eventFired
-         */
-
-        /**
-         * Add event listener to dom object (cross browser function)
-         * @param {Element} elem
-         * @param {string} event
-         * @param {eventFired} fn
-         * @param {boolean} [isPassive]
-         */
-        var _addEvent = function(elem, event, fn, isPassive) {
-            elem.addEventListener(event, fn , isPassive === true ? { passive: true } : false);
-        }
-
-        /**
-         * Get all prop. keys defined inside object
-         * @param {Object} obj
-         */
-        var _getKeys = function(obj){
-            if(typeof obj === "object"){
-                return Object.keys(obj);
-            }
-        }
-
-        /**
-         * Append class to the specified dom element
-         * @param {HTMLElement} elem
-         * @param {string} classname
-         */
-        var _addClass = function (elem, classname){
-            elem.classList.add(classname);
-        }
-
-        /**
-         * Remove specified class from dom element
-         * @param {HTMLElement} elem
-         * @param {string} classname
-         */
-        var _removeClass = function (el, className) {
-            el.classList.remove(className);
-        }
-
-        /**
-         * Check if html element has class
-         * @param {HTMLElement} el
-         * @param {string} className
-         */
-        var _hasClass = function(el, className) {
-            return el.classList.contains(className);
-        }
-
-        return _cookieconsent;
+    var ENABLE_LOGS = true;
+
+    var _config = {
+      mode: "opt-in", // 'opt-in', 'opt-out'
+      current_lang: "en",
+      auto_language: null,
+      autorun: true, // run as soon as loaded
+      page_scripts: true,
+      hide_from_bots: true,
+      cookie_name: "cc_cookie",
+      cookie_expiration: 182, // default: 6 months (in days)
+      cookie_domain: window.location.hostname, // default: current domain
+      cookie_path: "/",
+      cookie_same_site: "Lax",
+      use_rfc_cookie: false,
+      autoclear_cookies: true,
+      revision: 0,
+      script_selector: "data-cookiecategory",
     };
 
-    var init = 'initCookieConsent';
+    var /**
+       * Object which holds the main methods/API (.show, .run, ...)
+       */
+      _cookieconsent = {},
+      /**
+       * Global user configuration object
+       */
+      user_config,
+      /**
+       * Internal state variables
+       */
+      saved_cookie_content = {},
+      cookie_data = null,
+      /**
+       * @type {Date}
+       */
+      consent_date,
+      /**
+       * @type {Date}
+       */
+      last_consent_update,
+      /**
+       * @type {string}
+       */
+      consent_uuid,
+      /**
+       * @type {boolean}
+       */
+      invalid_consent = true,
+      consent_modal_exists = false,
+      consent_modal_visible = false,
+      settings_modal_visible = false,
+      clicked_inside_modal = false,
+      current_modal_focusable,
+      all_table_headers,
+      all_blocks,
+      // Helper callback functions
+      // (avoid calling "user_config['onAccept']" all the time)
+      onAccept,
+      onChange,
+      onFirstAction,
+      revision_enabled = false,
+      valid_revision = true,
+      revision_message = "",
+      // State variables for the autoclearCookies function
+      changed_settings = [],
+      reload_page = false;
+
     /**
-     * Make CookieConsent object accessible globally
+     * Accept type:
+     *  - "all"
+     *  - "necessary"
+     *  - "custom"
+     * @type {string}
      */
-    if(typeof window !== 'undefined' && typeof window[init] !== 'function'){
-        window[init] = CookieConsent
-    }
+    var accept_type;
+
+    /**
+     * Contains all accepted categories
+     * @type {string[]}
+     */
+    var accepted_categories = [];
+
+    /**
+     * Contains all non-accepted (rejected) categories
+     * @type {string[]}
+     */
+    var rejected_categories = [];
+
+    /**
+     * Contains all categories enabled by default
+     * @type {string[]}
+     */
+    var default_enabled_categories = [];
+
+    // Don't run plugin (to avoid indexing its text content) if bot detected
+    var is_bot = false;
+
+    /**
+     * Save reference to the last focused element on the page
+     * (used later to restore focus when both modals are closed)
+     */
+    var last_elem_before_modal;
+    var last_consent_modal_btn_focus;
+
+    /**
+     * Both of the arrays below have the same structure:
+     * [0] => holds reference to the FIRST focusable element inside modal
+     * [1] => holds reference to the LAST focusable element inside modal
+     */
+    var consent_modal_focusable = [];
+    var settings_modal_focusable = [];
+
+    /**
+     * Keep track of enabled/disabled categories
+     * @type {boolean[]}
+     */
+    var toggle_states = [];
+
+    /**
+     * Stores all available categories
+     * @type {string[]}
+     */
+    var all_categories = [];
+
+    /**
+     * Keep track of readonly toggles
+     * @type {boolean[]}
+     */
+    var readonly_categories = [];
+
+    /**
+     * Pointers to main dom elements (to avoid retrieving them later using document.getElementById)
+     */
+    var /** @type {HTMLElement} */ html_dom = document.documentElement,
+      /** @type {HTMLElement} */ main_container,
+      /** @type {HTMLElement} */ all_modals_container,
+      /** @type {HTMLElement} */ consent_modal,
+      /** @type {HTMLElement} */ consent_modal_title,
+      /** @type {HTMLElement} */ consent_modal_description,
+      /** @type {HTMLElement} */ consent_primary_btn,
+      /** @type {HTMLElement} */ consent_secondary_btn,
+      /** @type {HTMLElement} */ consent_buttons,
+      /** @type {HTMLElement} */ consent_modal_inner,
+      /** @type {HTMLElement} */ settings_container,
+      /** @type {HTMLElement} */ settings_inner,
+      /** @type {HTMLElement} */ settings_title,
+      /** @type {HTMLElement} */ settings_close_btn,
+      /** @type {HTMLElement} */ settings_blocks,
+      /** @type {HTMLElement} */ new_settings_blocks,
+      /** @type {HTMLElement} */ settings_buttons,
+      /** @type {HTMLElement} */ settings_save_btn,
+      /** @type {HTMLElement} */ settings_accept_all_btn,
+      /** @type {HTMLElement} */ settings_reject_all_btn;
+
+    /**
+     * Update config settings
+     * @param {Object} user_config
+     */
+    var _setConfig = function (_user_config) {
+      /**
+       * Make user configuration globally available
+       */
+      user_config = _user_config;
+
+      _log("CookieConsent [CONFIG]: received_config_settings ", user_config);
+
+      if (typeof user_config["cookie_expiration"] === "number")
+        _config.cookie_expiration = user_config["cookie_expiration"];
+
+      if (typeof user_config["cookie_necessary_only_expiration"] === "number")
+        _config.cookie_necessary_only_expiration =
+          user_config["cookie_necessary_only_expiration"];
+
+      if (typeof user_config["autorun"] === "boolean")
+        _config.autorun = user_config["autorun"];
+
+      if (typeof user_config["cookie_domain"] === "string")
+        _config.cookie_domain = user_config["cookie_domain"];
+
+      if (typeof user_config["cookie_same_site"] === "string")
+        _config.cookie_same_site = user_config["cookie_same_site"];
+
+      if (typeof user_config["cookie_path"] === "string")
+        _config.cookie_path = user_config["cookie_path"];
+
+      if (typeof user_config["cookie_name"] === "string")
+        _config.cookie_name = user_config["cookie_name"];
+
+      if (typeof user_config["onAccept"] === "function")
+        onAccept = user_config["onAccept"];
+
+      if (typeof user_config["onFirstAction"] === "function")
+        onFirstAction = user_config["onFirstAction"];
+
+      if (typeof user_config["onChange"] === "function")
+        onChange = user_config["onChange"];
+
+      if (user_config["mode"] === "opt-out") _config.mode = "opt-out";
+
+      if (typeof user_config["revision"] === "number") {
+        user_config["revision"] > -1 &&
+          (_config.revision = user_config["revision"]);
+        revision_enabled = true;
+      }
+
+      if (typeof user_config["autoclear_cookies"] === "boolean")
+        _config.autoclear_cookies = user_config["autoclear_cookies"];
+
+      if (user_config["use_rfc_cookie"] === true) _config.use_rfc_cookie = true;
+
+      if (user_config["hide_from_bots"] === true) {
+        is_bot =
+          navigator &&
+          ((navigator.userAgent &&
+            /bot|crawl|spider|slurp|teoma/i.test(navigator.userAgent)) ||
+            navigator.webdriver);
+      }
+
+      _config.page_scripts = user_config["page_scripts"] === true;
+
+      if (
+        user_config["auto_language"] === "browser" ||
+        user_config["auto_language"] === true
+      ) {
+        _config.auto_language = "browser";
+      } else if (user_config["auto_language"] === "document") {
+        _config.auto_language = "document";
+      }
+
+      _log(
+        "CookieConsent [LANG]: auto_language strategy is '" +
+          _config.auto_language +
+          "'"
+      );
+
+      _config.current_lang = _resolveCurrentLang(
+        user_config.languages,
+        user_config["current_lang"]
+      );
+    };
+
+    // /**
+    //  * Print consent date
+    //  */
+    // var _printConsentDateHTML = function(){
+    //     if(!consent_date) return;
+
+    //     var consent_date_elements = document.querySelectorAll('[data-cc="consent-date"]');
+    //     var last_consent_update_elements = document.querySelectorAll('[data-cc="last-consent-update"]');
+
+    //     for(var i=0; i<consent_date_elements.length; i++)
+    //         consent_date_elements[i].textContent = consent_date.toLocaleString();
+
+    //     for(var i=0; i<last_consent_update_elements.length; i++)
+    //         last_consent_update_elements[i].textContent = last_consent_update.toLocaleString();
+    // }
+
+    /**
+     * Add an onClick listeners to all html elements with data-cc attribute
+     */
+    var _addDataButtonListeners = function (elem) {
+      var _a = "accept-";
+
+      var show_settings = _getElements("c-settings");
+      var accept_all = _getElements(_a + "all");
+      var accept_necessary = _getElements(_a + "necessary");
+      var accept_custom_selection = _getElements(_a + "custom");
+
+      for (var i = 0; i < show_settings.length; i++) {
+        show_settings[i].setAttribute("aria-haspopup", "dialog");
+        _addEvent(show_settings[i], "click", function (event) {
+          event.preventDefault();
+          _cookieconsent.showSettings(0);
+        });
+      }
+
+      for (i = 0; i < accept_all.length; i++) {
+        _addEvent(accept_all[i], "click", function (event) {
+          _acceptAction(event, "all");
+        });
+      }
+
+      for (i = 0; i < accept_custom_selection.length; i++) {
+        _addEvent(accept_custom_selection[i], "click", function (event) {
+          _acceptAction(event);
+        });
+      }
+
+      for (i = 0; i < accept_necessary.length; i++) {
+        _addEvent(accept_necessary[i], "click", function (event) {
+          _acceptAction(event, []);
+        });
+      }
+
+      /**
+       * Return all elements with given data-cc role
+       * @param {string} data_role
+       * @returns {NodeListOf<Element>}
+       */
+      function _getElements(data_role) {
+        return (elem || document).querySelectorAll(
+          'a[data-cc="' + data_role + '"], button[data-cc="' + data_role + '"]'
+        );
+      }
+
+      /**
+       * Helper function: accept and then hide modals
+       * @param {PointerEvent} e source event
+       * @param {string} [accept_type]
+       */
+      function _acceptAction(e, accept_type) {
+        e.preventDefault();
+        _cookieconsent.accept(accept_type);
+        _cookieconsent.hideSettings();
+        _cookieconsent.hide();
+      }
+
+      //_printConsentDateHTML();
+    };
+
+    /**
+     * Get a valid language (at least 1 must be defined)
+     * @param {string} lang - desired language
+     * @param {Object} all_languages - all defined languages
+     * @returns {string} validated language
+     */
+    var _getValidatedLanguage = function (lang, all_languages) {
+      if (Object.prototype.hasOwnProperty.call(all_languages, lang)) {
+        return lang;
+      } else if (_getKeys(all_languages).length > 0) {
+        if (
+          Object.prototype.hasOwnProperty.call(
+            all_languages,
+            _config.current_lang
+          )
+        ) {
+          return _config.current_lang;
+        } else {
+          return _getKeys(all_languages)[0];
+        }
+      }
+    };
+
+    /**
+     * Save reference to first and last focusable elements inside each modal
+     * to prevent losing focus while navigating with TAB
+     */
+    var _getModalFocusableData = function () {
+      /**
+       * Note: any of the below focusable elements, which has the attribute tabindex="-1" AND is either
+       * the first or last element of the modal, won't receive focus during "open/close" modal
+       */
+      var allowed_focusable_types = [
+        "[href]",
+        "button",
+        "input",
+        "details",
+        '[tabindex="0"]',
+      ];
+
+      function _getAllFocusableElements(modal, _array) {
+        var focus_later = false,
+          focus_first = false;
+
+        // ie might throw exception due to complex unsupported selector => a:not([tabindex="-1"])
+        try {
+          var focusable_elems = modal.querySelectorAll(
+            allowed_focusable_types.join(':not([tabindex="-1"]), ')
+          );
+          var attr,
+            len = focusable_elems.length,
+            i = 0;
+
+          while (i < len) {
+            attr = focusable_elems[i].getAttribute("data-focus");
+
+            if (!focus_first && attr === "1") {
+              focus_first = focusable_elems[i];
+            } else if (attr === "0") {
+              focus_later = focusable_elems[i];
+              if (
+                !focus_first &&
+                focusable_elems[i + 1].getAttribute("data-focus") !== "0"
+              ) {
+                focus_first = focusable_elems[i + 1];
+              }
+            }
+
+            i++;
+          }
+        } catch (e) {
+          return modal.querySelectorAll(allowed_focusable_types.join(", "));
+        }
+
+        /**
+         * Save first and last elements (used to lock/trap focus inside modal)
+         */
+        _array[0] = focusable_elems[0];
+        _array[1] = focusable_elems[focusable_elems.length - 1];
+        _array[2] = focus_later;
+        _array[3] = focus_first;
+      }
+
+      /**
+       * Get settings modal'S all focusable elements
+       * Save first and last elements (used to lock/trap focus inside modal)
+       */
+      _getAllFocusableElements(settings_inner, settings_modal_focusable);
+
+      /**
+       * If consent modal exists, do the same
+       */
+      if (consent_modal_exists) {
+        _getAllFocusableElements(consent_modal, consent_modal_focusable);
+      }
+    };
+
+    var _createConsentModal = function (lang) {
+      if (user_config["force_consent"] === true)
+        _addClass(html_dom, "force--consent");
+
+      // Create modal if it doesn't exist
+      if (!consent_modal) {
+        consent_modal = _createNode("div");
+        var consent_modal_inner_inner = _createNode("div");
+        var overlay = _createNode("div");
+
+        consent_modal.id = "cm";
+        consent_modal_inner_inner.id = "c-inr-i";
+        overlay.id = "cm-ov";
+
+        consent_modal.setAttribute("role", "dialog");
+        consent_modal.setAttribute("aria-modal", "true");
+        consent_modal.setAttribute("aria-hidden", "false");
+        consent_modal.setAttribute("aria-labelledby", "c-ttl");
+        consent_modal.setAttribute("aria-describedby", "c-txt");
+
+        // Append consent modal to main container
+        all_modals_container.appendChild(consent_modal);
+        all_modals_container.appendChild(overlay);
+
+        /**
+         * Make modal by default hidden to prevent weird page jumps/flashes (shown only once css is loaded)
+         */
+        consent_modal.style.visibility = overlay.style.visibility = "hidden";
+        overlay.style.opacity = 0;
+      }
+
+      // Use insertAdjacentHTML instead of innerHTML
+      var consent_modal_title_value =
+        user_config.languages[lang]["consent_modal"]["title"];
+
+      // Add title (if valid)
+      if (consent_modal_title_value) {
+        if (!consent_modal_title) {
+          consent_modal_title = _createNode("div");
+          consent_modal_title.id = "c-ttl";
+          consent_modal_title.setAttribute("role", "heading");
+          consent_modal_title.setAttribute("aria-level", "2");
+          consent_modal_inner_inner.appendChild(consent_modal_title);
+        }
+
+        consent_modal_title.innerHTML = consent_modal_title_value;
+      }
+
+      var description =
+        user_config.languages[lang]["consent_modal"]["description"];
+
+      if (revision_enabled) {
+        if (!valid_revision) {
+          description = description.replace(
+            "{{revision_message}}",
+            revision_message ||
+              user_config.languages[lang]["consent_modal"][
+                "revision_message"
+              ] ||
+              ""
+          );
+        } else {
+          description = description.replace("{{revision_message}}", "");
+        }
+      }
+
+      if (!consent_modal_description) {
+        consent_modal_description = _createNode("div");
+        consent_modal_description.id = "c-txt";
+        consent_modal_inner_inner.appendChild(consent_modal_description);
+      }
+
+      // Set description content
+      consent_modal_description.innerHTML = description;
+
+      var primary_btn_data =
+          user_config.languages[lang]["consent_modal"]["primary_btn"], // accept current selection
+        secondary_btn_data =
+          user_config.languages[lang]["consent_modal"]["secondary_btn"];
+
+      // Add primary button if not falsy
+      if (primary_btn_data) {
+        if (!consent_primary_btn) {
+          consent_primary_btn = _createNode("button");
+          consent_primary_btn.id = "c-p-bn";
+          consent_primary_btn.className = "c-bn";
+
+          var _accept_type;
+
+          if (primary_btn_data["role"] === "accept_all") _accept_type = "all";
+
+          _addEvent(consent_primary_btn, "click", function () {
+            _cookieconsent.hide();
+            _log("CookieConsent [ACCEPT]: cookie_consent was accepted!");
+            _cookieconsent.accept(_accept_type);
+          });
+        }
+
+        consent_primary_btn.innerHTML =
+          user_config.languages[lang]["consent_modal"]["primary_btn"]["text"];
+      }
+
+      // Add secondary button if not falsy
+      if (secondary_btn_data) {
+        if (!consent_secondary_btn) {
+          consent_secondary_btn = _createNode("button");
+          consent_secondary_btn.id = "c-s-bn";
+          consent_secondary_btn.className = "c-bn c_link";
+
+          if (secondary_btn_data["role"] === "accept_necessary") {
+            _addEvent(consent_secondary_btn, "click", function () {
+              _cookieconsent.hide();
+              _cookieconsent.accept([]); // accept necessary only
+            });
+          } else {
+            _addEvent(consent_secondary_btn, "click", function () {
+              _cookieconsent.showSettings(0);
+            });
+          }
+        }
+
+        consent_secondary_btn.innerHTML =
+          user_config.languages[lang]["consent_modal"]["secondary_btn"]["text"];
+      }
+
+      // Swap buttons
+      var gui_options_data = user_config["gui_options"];
+
+      if (!consent_modal_inner) {
+        consent_modal_inner = _createNode("div");
+        consent_modal_inner.id = "c-inr";
+
+        consent_modal_inner.appendChild(consent_modal_inner_inner);
+      }
+
+      if (!consent_buttons) {
+        consent_buttons = _createNode("div");
+        consent_buttons.id = "c-bns";
+
+        if (
+          gui_options_data &&
+          gui_options_data["consent_modal"] &&
+          gui_options_data["consent_modal"]["swap_buttons"] === true
+        ) {
+          secondary_btn_data &&
+            consent_buttons.appendChild(consent_secondary_btn);
+          primary_btn_data && consent_buttons.appendChild(consent_primary_btn);
+          consent_buttons.className = "swap";
+        } else {
+          primary_btn_data && consent_buttons.appendChild(consent_primary_btn);
+          secondary_btn_data &&
+            consent_buttons.appendChild(consent_secondary_btn);
+        }
+
+        (primary_btn_data || secondary_btn_data) &&
+          consent_modal_inner.appendChild(consent_buttons);
+        consent_modal.appendChild(consent_modal_inner);
+      }
+
+      // add links to privacy and imprint
+      const consent_links = _createNode("div");
+      consent_links.id = "c-link";
+
+      const consent_links_imprint = _createNode("div");
+      consent_links_imprint.classList.add("cc-link");
+      consent_links_imprint.innerHTML = `<a href="/imprint">Imprint</a>`;
+      consent_links.appendChild(consent_links_imprint);
+
+      const consent_links_privacy = _createNode("div");
+      consent_links_privacy.classList.add("cc-link");
+      consent_links_privacy.innerHTML = `<a href="/privacy">Privacy</a>`;
+      consent_links.appendChild(consent_links_privacy);
+
+      consent_modal_inner.appendChild(consent_links);
+
+      consent_modal_exists = true;
+    };
+
+    var _createSettingsModal = function (lang) {
+      /**
+       * Create all consent_modal elements
+       */
+      if (!settings_container) {
+        settings_container = _createNode("div");
+        var settings_container_valign = _createNode("div");
+        var settings = _createNode("div");
+        var settings_container_inner = _createNode("div");
+        settings_inner = _createNode("div");
+        settings_title = _createNode("div");
+        var settings_header = _createNode("div");
+        settings_close_btn = _createNode("button");
+        var settings_close_btn_container = _createNode("div");
+        settings_blocks = _createNode("div");
+        var overlay = _createNode("div");
+
+        /**
+         * Set ids
+         */
+        settings_container.id = "s-cnt";
+        settings_container_valign.id = "c-vln";
+        settings_container_inner.id = "c-s-in";
+        settings.id = "cs";
+        settings_title.id = "s-ttl";
+        settings_inner.id = "s-inr";
+        settings_header.id = "s-hdr";
+        settings_blocks.id = "s-bl";
+        settings_close_btn.id = "s-c-bn";
+        overlay.id = "cs-ov";
+        settings_close_btn_container.id = "s-c-bnc";
+        settings_close_btn.className = "c-bn";
+
+        settings_container.setAttribute("role", "dialog");
+        settings_container.setAttribute("aria-modal", "true");
+        settings_container.setAttribute("aria-hidden", "true");
+        settings_container.setAttribute("aria-labelledby", "s-ttl");
+        settings_title.setAttribute("role", "heading");
+        settings_container.style.visibility = overlay.style.visibility =
+          "hidden";
+        overlay.style.opacity = 0;
+
+        settings_close_btn_container.appendChild(settings_close_btn);
+
+        // If 'esc' key is pressed inside settings_container div => hide settings
+        _addEvent(
+          settings_container_valign,
+          "keydown",
+          function (evt) {
+            evt = evt || window.event;
+            if (evt.keyCode === 27) {
+              _cookieconsent.hideSettings(0);
+            }
+          },
+          true
+        );
+
+        _addEvent(settings_close_btn, "click", function () {
+          _cookieconsent.hideSettings(0);
+        });
+      } else {
+        new_settings_blocks = _createNode("div");
+        new_settings_blocks.id = "s-bl";
+      }
+
+      // Add label to close button
+      settings_close_btn.setAttribute(
+        "aria-label",
+        user_config.languages[lang]["settings_modal"]["close_btn_label"] ||
+          "Close"
+      );
+
+      all_blocks = user_config.languages[lang]["settings_modal"]["blocks"];
+      all_table_headers =
+        user_config.languages[lang]["settings_modal"]["cookie_table_headers"];
+
+      var n_blocks = all_blocks.length;
+
+      // Set settings modal title
+      settings_title.innerHTML =
+        user_config.languages[lang]["settings_modal"]["title"];
+
+      // Create settings modal content (blocks)
+      for (var i = 0; i < n_blocks; ++i) {
+        var title_data = all_blocks[i]["title"],
+          description_data = all_blocks[i]["description"],
+          toggle_data = all_blocks[i]["toggle"],
+          cookie_table_data = all_blocks[i]["cookie_table"],
+          remove_cookie_tables = user_config["remove_cookie_tables"] === true,
+          isExpandable =
+            (description_data && "truthy") ||
+            (!remove_cookie_tables && cookie_table_data && "truthy");
+
+        // Create title
+        var block_section = _createNode("div");
+        var block_table_container = _createNode("div");
+
+        // Create description
+        if (description_data) {
+          var block_desc = _createNode("div");
+          block_desc.className = "p";
+          block_desc.insertAdjacentHTML("beforeend", description_data);
+        }
+
+        var block_title_container = _createNode("div");
+        block_title_container.className = "title";
+
+        block_section.className = "c-bl";
+        block_table_container.className = "desc";
+
+        // Create toggle if specified (opt in/out)
+        if (typeof toggle_data !== "undefined") {
+          var accordion_id = "c-ac-" + i;
+
+          // Create button (to collapse/expand block description)
+          var block_title_btn = isExpandable
+            ? _createNode("button")
+            : _createNode("div");
+          var block_switch_label = _createNode("label");
+          var block_switch = _createNode("input");
+          var block_switch_span = _createNode("span");
+          var label_text_span = _createNode("span");
+
+          // These 2 spans will contain each 2 pseudo-elements to generate 'tick' and 'x' icons
+          var block_switch_span_on_icon = _createNode("span");
+          var block_switch_span_off_icon = _createNode("span");
+
+          block_title_btn.className = isExpandable ? "b-tl exp" : "b-tl";
+          block_switch_label.className = "b-tg";
+          block_switch.className = "c-tgl";
+          block_switch_span_on_icon.className = "on-i";
+          block_switch_span_off_icon.className = "off-i";
+          block_switch_span.className = "c-tg";
+          label_text_span.className = "t-lb";
+
+          if (isExpandable) {
+            block_title_btn.setAttribute("aria-expanded", "false");
+            block_title_btn.setAttribute("aria-controls", accordion_id);
+          }
+
+          block_switch.type = "checkbox";
+          block_switch_span.setAttribute("aria-hidden", "true");
+
+          var cookie_category = toggle_data.value;
+          block_switch.value = cookie_category;
+
+          label_text_span.textContent = title_data;
+          block_title_btn.insertAdjacentHTML("beforeend", title_data);
+
+          block_title_container.appendChild(block_title_btn);
+          block_switch_span.appendChild(block_switch_span_on_icon);
+          block_switch_span.appendChild(block_switch_span_off_icon);
+
+          /**
+           * If consent is valid => retrieve category states from cookie
+           * Otherwise use states defined in the user_config. object
+           */
+          if (!invalid_consent) {
+            if (
+              _inArray(saved_cookie_content["categories"], cookie_category) > -1
+            ) {
+              block_switch.checked = true;
+              !new_settings_blocks && toggle_states.push(true);
+            } else {
+              !new_settings_blocks && toggle_states.push(false);
+            }
+          } else if (toggle_data["enabled"]) {
+            block_switch.checked = true;
+            !new_settings_blocks && toggle_states.push(true);
+
+            /**
+             * Keep track of categories enabled by default (useful when mode=='opt-out')
+             */
+            if (toggle_data["enabled"])
+              !new_settings_blocks &&
+                default_enabled_categories.push(cookie_category);
+          } else {
+            !new_settings_blocks && toggle_states.push(false);
+          }
+
+          !new_settings_blocks && all_categories.push(cookie_category);
+
+          /**
+           * Set toggle as readonly if true (disable checkbox)
+           */
+          if (toggle_data["readonly"]) {
+            block_switch.disabled = true;
+            _addClass(block_switch_span, "c-ro");
+            !new_settings_blocks && readonly_categories.push(true);
+          } else {
+            !new_settings_blocks && readonly_categories.push(false);
+          }
+
+          _addClass(block_table_container, "b-acc");
+          _addClass(block_title_container, "b-bn");
+          _addClass(block_section, "b-ex");
+
+          block_table_container.id = accordion_id;
+          block_table_container.setAttribute("aria-hidden", "true");
+
+          block_switch_label.appendChild(block_switch);
+          block_switch_label.appendChild(block_switch_span);
+          block_switch_label.appendChild(label_text_span);
+          block_title_container.appendChild(block_switch_label);
+
+          /**
+           * On button click handle the following :=> aria-expanded, aria-hidden and act class for current block
+           */
+          isExpandable &&
+            (function (accordion, block_section, btn) {
+              _addEvent(
+                block_title_btn,
+                "click",
+                function () {
+                  if (!_hasClass(block_section, "act")) {
+                    _addClass(block_section, "act");
+                    btn.setAttribute("aria-expanded", "true");
+                    accordion.setAttribute("aria-hidden", "false");
+                  } else {
+                    _removeClass(block_section, "act");
+                    btn.setAttribute("aria-expanded", "false");
+                    accordion.setAttribute("aria-hidden", "true");
+                  }
+                },
+                false
+              );
+            })(block_table_container, block_section, block_title_btn);
+        } else {
+          /**
+           * If block is not a button (no toggle defined),
+           * create a simple div instead
+           */
+          if (title_data) {
+            var block_title = _createNode("div");
+            block_title.className = "b-tl";
+            block_title.setAttribute("role", "heading");
+            block_title.setAttribute("aria-level", "3");
+            block_title.insertAdjacentHTML("beforeend", title_data);
+            block_title_container.appendChild(block_title);
+          }
+        }
+
+        title_data && block_section.appendChild(block_title_container);
+        description_data && block_table_container.appendChild(block_desc);
+
+        // if cookie table found, generate table for this block
+        if (!remove_cookie_tables && typeof cookie_table_data !== "undefined") {
+          var tr_tmp_fragment = document.createDocumentFragment();
+
+          /**
+           * Use custom table headers
+           */
+          for (var p = 0; p < all_table_headers.length; ++p) {
+            // create new header
+            var th1 = _createNode("th");
+            var obj = all_table_headers[p];
+            th1.setAttribute("scope", "col");
+
+            // get custom header content
+            if (obj) {
+              var new_column_key = obj && _getKeys(obj)[0];
+              th1.textContent = all_table_headers[p][new_column_key];
+              tr_tmp_fragment.appendChild(th1);
+            }
+          }
+
+          var tr_tmp = _createNode("tr");
+          tr_tmp.appendChild(tr_tmp_fragment);
+
+          // create table header & append fragment
+          var thead = _createNode("thead");
+          thead.appendChild(tr_tmp);
+
+          // append header to table
+          var block_table = _createNode("table");
+          block_table.appendChild(thead);
+
+          var tbody_fragment = document.createDocumentFragment();
+
+          // create table content
+          for (var n = 0; n < cookie_table_data.length; n++) {
+            var tr = _createNode("tr");
+
+            for (var g = 0; g < all_table_headers.length; ++g) {
+              // get custom header content
+              obj = all_table_headers[g];
+              if (obj) {
+                new_column_key = _getKeys(obj)[0];
+
+                var td_tmp = _createNode("td");
+
+                // Allow html inside table cells
+                td_tmp.insertAdjacentHTML(
+                  "beforeend",
+                  cookie_table_data[n][new_column_key]
+                );
+                td_tmp.setAttribute("data-column", obj[new_column_key]);
+
+                tr.appendChild(td_tmp);
+              }
+            }
+
+            tbody_fragment.appendChild(tr);
+          }
+
+          // append tbody_fragment to tbody & append the latter into the table
+          var tbody = _createNode("tbody");
+          tbody.appendChild(tbody_fragment);
+          block_table.appendChild(tbody);
+
+          block_table_container.appendChild(block_table);
+        }
+
+        /**
+         * Append only if is either:
+         * - togglable div with title
+         * - a simple div with at least a title or description
+         */
+        if (
+          (toggle_data && title_data) ||
+          (!toggle_data && (title_data || description_data))
+        ) {
+          block_section.appendChild(block_table_container);
+
+          if (new_settings_blocks)
+            new_settings_blocks.appendChild(block_section);
+          else settings_blocks.appendChild(block_section);
+        }
+      }
+
+      // Create settings buttons
+      if (!settings_buttons) {
+        settings_buttons = _createNode("div");
+        settings_buttons.id = "s-bns";
+      }
+
+      if (!settings_accept_all_btn) {
+        settings_accept_all_btn = _createNode("button");
+        settings_accept_all_btn.id = "s-all-bn";
+        settings_accept_all_btn.className = "c-bn";
+        settings_buttons.appendChild(settings_accept_all_btn);
+
+        _addEvent(settings_accept_all_btn, "click", function () {
+          _cookieconsent.hideSettings();
+          _cookieconsent.hide();
+          _cookieconsent.accept("all");
+        });
+      }
+
+      settings_accept_all_btn.innerHTML =
+        user_config.languages[lang]["settings_modal"]["accept_all_btn"];
+
+      var reject_all_btn_text =
+        user_config.languages[lang]["settings_modal"]["reject_all_btn"];
+
+      // Add third [optional] reject all button if provided
+      if (reject_all_btn_text) {
+        if (!settings_reject_all_btn) {
+          settings_reject_all_btn = _createNode("button");
+          settings_reject_all_btn.id = "s-rall-bn";
+          settings_reject_all_btn.className = "c-bn";
+
+          _addEvent(settings_reject_all_btn, "click", function () {
+            _cookieconsent.hideSettings();
+            _cookieconsent.hide();
+            _cookieconsent.accept([]);
+          });
+
+          settings_inner.className = "bns-t";
+          settings_buttons.appendChild(settings_reject_all_btn);
+        }
+
+        settings_reject_all_btn.innerHTML = reject_all_btn_text;
+      }
+
+      if (!settings_save_btn) {
+        settings_save_btn = _createNode("button");
+        settings_save_btn.id = "s-sv-bn";
+        settings_save_btn.className = "c-bn";
+        settings_buttons.appendChild(settings_save_btn);
+
+        // Add save preferences button onClick event
+        // Hide both settings modal and consent modal
+        _addEvent(settings_save_btn, "click", function () {
+          _cookieconsent.hideSettings();
+          _cookieconsent.hide();
+          _cookieconsent.accept();
+        });
+      }
+
+      settings_save_btn.innerHTML =
+        user_config.languages[lang]["settings_modal"]["save_settings_btn"];
+
+      if (new_settings_blocks) {
+        // replace entire existing cookie category blocks with the new cookie categories new blocks (in a different language)
+        settings_inner.replaceChild(new_settings_blocks, settings_blocks);
+        settings_blocks = new_settings_blocks;
+        return;
+      }
+
+      settings_header.appendChild(settings_title);
+      settings_header.appendChild(settings_close_btn_container);
+      settings_inner.appendChild(settings_header);
+      settings_inner.appendChild(settings_blocks);
+      settings_inner.appendChild(settings_buttons);
+      settings_container_inner.appendChild(settings_inner);
+
+      settings.appendChild(settings_container_inner);
+      settings_container_valign.appendChild(settings);
+      settings_container.appendChild(settings_container_valign);
+
+      all_modals_container.appendChild(settings_container);
+      all_modals_container.appendChild(overlay);
+    };
+
+    /**
+     * Generate cookie consent html markup
+     */
+    var _createCookieConsentHTML = function () {
+      // Create main container which holds both consent modal & settings modal
+      main_container = _createNode("div");
+      main_container.id = "cc--main";
+
+      // Fix layout flash
+      main_container.style.position = "fixed";
+      main_container.style.zIndex = "1000000";
+      main_container.innerHTML =
+        '<!--[if lt IE 9 ]><div id="cc_div" class="cc_div ie"></div><![endif]--><!--[if (gt IE 8)|!(IE)]><!--><div id="cc_div" class="cc_div"></div><!--<![endif]-->';
+      all_modals_container = main_container.children[0];
+
+      // Get current language
+      var lang = _config.current_lang;
+
+      // Create consent modal
+      if (consent_modal_exists) _createConsentModal(lang);
+
+      // Always create settings modal
+      _createSettingsModal(lang);
+
+      // Finally append everything (main_container holds both modals)
+      (root || document.body).appendChild(main_container);
+    };
+
+    /**
+     * Update/change modals language
+     * @param {String} lang new language
+     * @param {Boolean} [force] update language fields forcefully
+     * @returns {Boolean}
+     */
+    _cookieconsent.updateLanguage = function (lang, force) {
+      if (typeof lang !== "string") return;
+
+      /**
+       * Validate language to avoid errors
+       */
+      var new_validated_lang = _getValidatedLanguage(
+        lang,
+        user_config.languages
+      );
+
+      /**
+       * Set language only if it differs from current
+       */
+      if (new_validated_lang !== _config.current_lang || force === true) {
+        _config.current_lang = new_validated_lang;
+
+        if (consent_modal_exists) {
+          _createConsentModal(new_validated_lang);
+          _addDataButtonListeners(consent_modal_inner);
+        }
+
+        _createSettingsModal(new_validated_lang);
+
+        _log(
+          "CookieConsent [LANGUAGE]: curr_lang: '" + new_validated_lang + "'"
+        );
+
+        return true;
+      }
+
+      return false;
+    };
+
+    /**
+     * Delete all cookies which are unused (based on selected preferences)
+     *
+     * @param {boolean} [clearOnFirstAction]
+     */
+    var _autoclearCookies = function (clearOnFirstAction) {
+      // Get number of blocks
+      var len = all_blocks.length;
+      var count = -1;
+
+      // reset reload state
+      reload_page = false;
+
+      // Retrieve all cookies
+      var all_cookies_array = _getCookie("", "all");
+
+      // delete cookies on 'www.domain.com' and '.www.domain.com' (can also be without www)
+      var domains = [_config.cookie_domain, "." + _config.cookie_domain];
+
+      // if domain has www, delete cookies also for 'domain.com' and '.domain.com'
+      if (_config.cookie_domain.slice(0, 4) === "www.") {
+        var non_www_domain = _config.cookie_domain.substr(4); // remove first 4 chars (www.)
+        domains.push(non_www_domain);
+        domains.push("." + non_www_domain);
+      }
+
+      // For each block
+      for (var i = 0; i < len; i++) {
+        // Save current block (local scope & less accesses -> ~faster value retrieval)
+        var curr_block = all_blocks[i];
+
+        // If current block has a toggle for opt in/out
+        if (Object.prototype.hasOwnProperty.call(curr_block, "toggle")) {
+          // if current block has a cookie table, an off toggle,
+          // and its preferences were just changed => delete cookies
+          var category_just_disabled =
+            _inArray(changed_settings, curr_block["toggle"]["value"]) > -1;
+          if (
+            !toggle_states[++count] &&
+            Object.prototype.hasOwnProperty.call(curr_block, "cookie_table") &&
+            (clearOnFirstAction || category_just_disabled)
+          ) {
+            var curr_cookie_table = curr_block["cookie_table"];
+
+            // Get first property name
+            var ckey = _getKeys(all_table_headers[0])[0];
+
+            // Get number of cookies defined in cookie_table
+            var clen = curr_cookie_table.length;
+
+            // set "reload_page" to true if reload=on_disable
+            if (curr_block["toggle"]["reload"] === "on_disable")
+              category_just_disabled && (reload_page = true);
+
+            // for each row defined in the cookie table
+            for (var j = 0; j < clen; j++) {
+              // Get current row of table (corresponds to all cookie params)
+              var curr_row = curr_cookie_table[j],
+                found_cookies = [];
+              var curr_cookie_name = curr_row[ckey];
+              var is_regex = curr_row["is_regex"] || false;
+              var curr_cookie_domain = curr_row["domain"] || null;
+              var curr_cookie_path = curr_row["path"] || false;
+
+              // set domain to the specified domain
+              curr_cookie_domain &&
+                (domains = [curr_cookie_domain, "." + curr_cookie_domain]);
+
+              // If regex provided => filter cookie array
+              if (is_regex) {
+                for (var n = 0; n < all_cookies_array.length; n++) {
+                  if (all_cookies_array[n].match(curr_cookie_name)) {
+                    found_cookies.push(all_cookies_array[n]);
+                  }
+                }
+              } else {
+                var found_index = _inArray(all_cookies_array, curr_cookie_name);
+                if (found_index > -1)
+                  found_cookies.push(all_cookies_array[found_index]);
+              }
+
+              _log(
+                "CookieConsent [AUTOCLEAR]: search cookie: '" +
+                  curr_cookie_name +
+                  "', found:",
+                found_cookies
+              );
+
+              // If cookie exists -> delete it
+              if (found_cookies.length > 0) {
+                _eraseCookies(found_cookies, curr_cookie_path, domains);
+                curr_block["toggle"]["reload"] === "on_clear" &&
+                  (reload_page = true);
+              }
+            }
+          }
+        }
+      }
+    };
+
+    /**
+     * Set toggles/checkboxes based on accepted categories and save cookie
+     * @param {string[]} accepted_categories - Array of categories to accept
+     */
+    var _saveCookiePreferences = function (accepted_categories) {
+      changed_settings = [];
+
+      // Retrieve all toggle/checkbox values
+      var category_toggles = document.querySelectorAll(".c-tgl") || [];
+
+      // If there are opt in/out toggles ...
+      if (category_toggles.length > 0) {
+        for (var i = 0; i < category_toggles.length; i++) {
+          if (_inArray(accepted_categories, all_categories[i]) !== -1) {
+            category_toggles[i].checked = true;
+            if (!toggle_states[i]) {
+              changed_settings.push(all_categories[i]);
+              toggle_states[i] = true;
+            }
+          } else {
+            category_toggles[i].checked = false;
+            if (toggle_states[i]) {
+              changed_settings.push(all_categories[i]);
+              toggle_states[i] = false;
+            }
+          }
+        }
+      }
+
+      /**
+       * Clear cookies when settings/preferences change
+       */
+      if (
+        !invalid_consent &&
+        _config.autoclear_cookies &&
+        changed_settings.length > 0
+      )
+        _autoclearCookies();
+
+      if (!consent_date) consent_date = new Date();
+      if (!consent_uuid) consent_uuid = _uuidv4();
+
+      saved_cookie_content = {
+        categories: accepted_categories,
+        revision: _config.revision,
+        data: cookie_data,
+        rfc_cookie: _config.use_rfc_cookie,
+        consent_date: consent_date.toISOString(),
+        consent_uuid: consent_uuid,
+      };
+
+      // save cookie with preferences 'categories' (only if never accepted or settings were updated)
+      if (invalid_consent || changed_settings.length > 0) {
+        valid_revision = true;
+
+        /**
+         * Update "last_consent_update" only if it is invalid (after t)
+         */
+        if (!last_consent_update) last_consent_update = consent_date;
+        else last_consent_update = new Date();
+
+        saved_cookie_content["last_consent_update"] =
+          last_consent_update.toISOString();
+
+        /**
+         * Update accept type
+         */
+        accept_type = _getAcceptType(_getCurrentCategoriesState());
+
+        _setCookie(_config.cookie_name, JSON.stringify(saved_cookie_content));
+        _manageExistingScripts();
+
+        //_printConsentDateHTML();
+      }
+
+      if (invalid_consent) {
+        /**
+         * Delete unused/"zombie" cookies if consent is not valid (not yet expressed or cookie has expired)
+         */
+        if (_config.autoclear_cookies) _autoclearCookies(true);
+
+        if (typeof onFirstAction === "function")
+          onFirstAction(
+            _cookieconsent.getUserPreferences(),
+            saved_cookie_content
+          );
+
+        if (typeof onAccept === "function") onAccept(saved_cookie_content);
+
+        /**
+         * Set consent as valid
+         */
+        invalid_consent = false;
+
+        if (_config.mode === "opt-in") return;
+      }
+
+      // fire onChange only if settings were changed
+      if (typeof onChange === "function" && changed_settings.length > 0)
+        onChange(saved_cookie_content, changed_settings);
+
+      /**
+       * reload page if needed
+       */
+      if (reload_page) window.location.reload();
+    };
+
+    /**
+     * Returns index of found element inside array, otherwise -1
+     * @param {Array} arr
+     * @param {Object} value
+     * @returns {number}
+     */
+    var _inArray = function (arr, value) {
+      return arr.indexOf(value);
+    };
+
+    /**
+     * Helper function which prints info (console.log())
+     * @param {Object} print_msg
+     * @param {Object} [optional_param]
+     */
+    var _log = function (print_msg, optional_param, error) {
+      ENABLE_LOGS &&
+        (!error
+          ? console.log(
+              print_msg,
+              optional_param !== undefined ? optional_param : " "
+            )
+          : console.error(print_msg, optional_param || ""));
+    };
+
+    /**
+     * Helper function which creates an HTMLElement object based on 'type' and returns it.
+     * @param {string} type
+     * @returns {HTMLElement}
+     */
+    var _createNode = function (type) {
+      var el = document.createElement(type);
+      if (type === "button") {
+        el.setAttribute("type", type);
+      }
+      return el;
+    };
+
+    /**
+     * Generate RFC4122-compliant UUIDs.
+     * https://stackoverflow.com/questions/105034/how-to-create-a-guid-uuid?page=1&tab=votes#tab-top
+     * @returns {string}
+     */
+    var _uuidv4 = function () {
+      return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(
+        /[018]/g,
+        function (c) {
+          return (
+            c ^
+            ((window.crypto || window.msCrypto).getRandomValues(
+              new Uint8Array(1)
+            )[0] &
+              (15 >> (c / 4)))
+          ).toString(16);
+        }
+      );
+    };
+
+    /**
+     * Resolve which language should be used.
+     *
+     * @param {Object} languages Object with language translations
+     * @param {string} [requested_language] Language specified by given configuration parameters
+     * @returns {string}
+     */
+    var _resolveCurrentLang = function (languages, requested_language) {
+      if (_config.auto_language === "browser") {
+        return _getValidatedLanguage(_getBrowserLang(), languages);
+      } else if (_config.auto_language === "document") {
+        return _getValidatedLanguage(document.documentElement.lang, languages);
+      } else {
+        if (typeof requested_language === "string") {
+          return (_config.current_lang = _getValidatedLanguage(
+            requested_language,
+            languages
+          ));
+        }
+      }
+
+      _log(
+        "CookieConsent [LANG]: setting current_lang = '" +
+          _config.current_lang +
+          "'"
+      );
+      return _config.current_lang; // otherwise return default
+    };
+
+    /**
+     * Get current client's browser language
+     * @returns {string}
+     */
+    var _getBrowserLang = function () {
+      var browser_lang = navigator.language || navigator.browserLanguage;
+      browser_lang.length > 2 &&
+        (browser_lang = browser_lang[0] + browser_lang[1]);
+      _log(
+        "CookieConsent [LANG]: detected_browser_lang = '" + browser_lang + "'"
+      );
+      return browser_lang.toLowerCase();
+    };
+
+    /**
+     * Trap focus inside modal and focus the first
+     * focusable element of current active modal
+     */
+    var _handleFocusTrap = function () {
+      var tabbedOutsideDiv = false;
+      var tabbedInsideModal = false;
+
+      _addEvent(document, "keydown", function (e) {
+        e = e || window.event;
+
+        // If is tab key => ok
+        if (e.key !== "Tab") return;
+
+        // If there is any modal to focus
+        if (current_modal_focusable) {
+          // If reached natural end of the tab sequence => restart
+          if (e.shiftKey) {
+            if (document.activeElement === current_modal_focusable[0]) {
+              current_modal_focusable[1].focus();
+              e.preventDefault();
+            }
+          } else {
+            if (document.activeElement === current_modal_focusable[1]) {
+              current_modal_focusable[0].focus();
+              e.preventDefault();
+            }
+          }
+
+          // If have not yet used tab (or shift+tab) and modal is open ...
+          // Focus the first focusable element
+          if (!tabbedInsideModal && !clicked_inside_modal) {
+            tabbedInsideModal = true;
+            !tabbedOutsideDiv && e.preventDefault();
+
+            if (e.shiftKey) {
+              if (current_modal_focusable[3]) {
+                if (!current_modal_focusable[2]) {
+                  current_modal_focusable[0].focus();
+                } else {
+                  current_modal_focusable[2].focus();
+                }
+              } else {
+                current_modal_focusable[1].focus();
+              }
+            } else {
+              if (current_modal_focusable[3]) {
+                current_modal_focusable[3].focus();
+              } else {
+                current_modal_focusable[0].focus();
+              }
+            }
+          }
+        }
+
+        !tabbedInsideModal && (tabbedOutsideDiv = true);
+      });
+
+      if (document.contains) {
+        _addEvent(
+          main_container,
+          "click",
+          function (e) {
+            e = e || window.event;
+            /**
+             * If click is on the foreground overlay (and not inside settings_modal),
+             * hide settings modal
+             *
+             * Notice: click on div is not supported in IE
+             */
+            if (settings_modal_visible) {
+              if (!settings_inner.contains(e.target)) {
+                _cookieconsent.hideSettings(0);
+                clicked_inside_modal = false;
+              } else {
+                clicked_inside_modal = true;
+              }
+            } else if (consent_modal_visible) {
+              if (consent_modal.contains(e.target)) {
+                clicked_inside_modal = true;
+              }
+            }
+          },
+          true
+        );
+      }
+    };
+
+    /**
+     * Manage each modal's layout
+     * @param {Object} gui_options
+     */
+    var _guiManager = function (gui_options, only_consent_modal) {
+      // If gui_options is not object => exit
+      if (typeof gui_options !== "object") return;
+
+      var consent_modal_options = gui_options["consent_modal"];
+      var settings_modal_options = gui_options["settings_modal"];
+
+      /**
+       * Helper function which adds layout and
+       * position classes to given modal
+       *
+       * @param {HTMLElement} modal
+       * @param {string[]} allowed_layouts
+       * @param {string[]} allowed_positions
+       * @param {string} layout
+       * @param {string[]} position
+       */
+      function _setLayout(
+        modal,
+        allowed_layouts,
+        allowed_positions,
+        allowed_transitions,
+        layout,
+        position,
+        transition
+      ) {
+        position = (position && position.split(" ")) || [];
+
+        // Check if specified layout is valid
+        if (_inArray(allowed_layouts, layout) > -1) {
+          // Add layout classes
+          _addClass(modal, layout);
+
+          // Add position class (if specified)
+          if (
+            !(layout === "bar" && position[0] === "middle") &&
+            _inArray(allowed_positions, position[0]) > -1
+          ) {
+            for (var i = 0; i < position.length; i++) {
+              _addClass(modal, position[i]);
+            }
+          }
+        }
+
+        // Add transition class
+        _inArray(allowed_transitions, transition) > -1 &&
+          _addClass(modal, transition);
+      }
+
+      if (consent_modal_exists && consent_modal_options) {
+        _setLayout(
+          consent_modal,
+          ["box", "bar", "cloud"],
+          ["top", "middle", "bottom"],
+          ["zoom", "slide"],
+          consent_modal_options["layout"],
+          consent_modal_options["position"],
+          consent_modal_options["transition"]
+        );
+      }
+
+      if (!only_consent_modal && settings_modal_options) {
+        _setLayout(
+          settings_container,
+          ["bar"],
+          ["left", "right"],
+          ["zoom", "slide"],
+          settings_modal_options["layout"],
+          settings_modal_options["position"],
+          settings_modal_options["transition"]
+        );
+      }
+    };
+
+    /**
+     * Returns true if cookie category is accepted by the user
+     * @param {string} cookie_category
+     * @returns {boolean}
+     */
+    _cookieconsent.allowedCategory = function (cookie_category) {
+      if (!invalid_consent || _config.mode === "opt-in")
+        var allowed_categories =
+          JSON.parse(_getCookie(_config.cookie_name, "one", true) || "{}")[
+            "categories"
+          ] || [];
+      // mode is 'opt-out'
+      else var allowed_categories = default_enabled_categories;
+
+      return _inArray(allowed_categories, cookie_category) > -1;
+    };
+
+    /**
+     * "Init" method. Will run once and only if modals do not exist
+     */
+    _cookieconsent.run = function (user_config) {
+      if (!document.getElementById("cc_div")) {
+        // configure all parameters
+        _setConfig(user_config);
+
+        // if is bot, don't run plugin
+        if (is_bot) return;
+
+        // Retrieve cookie value (if set)
+        saved_cookie_content = JSON.parse(
+          _getCookie(_config.cookie_name, "one", true) || "{}"
+        );
+
+        // Retrieve "consent_uuid"
+        consent_uuid = saved_cookie_content["consent_uuid"];
+
+        // If "consent_uuid" is present => assume that consent was previously given
+        var cookie_consent_accepted = consent_uuid !== undefined;
+
+        // Retrieve "consent_date"
+        consent_date = saved_cookie_content["consent_date"];
+        consent_date && (consent_date = new Date(consent_date));
+
+        // Retrieve "last_consent_update"
+        last_consent_update = saved_cookie_content["last_consent_update"];
+        last_consent_update &&
+          (last_consent_update = new Date(last_consent_update));
+
+        // Retrieve "data"
+        cookie_data =
+          saved_cookie_content["data"] !== undefined
+            ? saved_cookie_content["data"]
+            : null;
+
+        // If revision is enabled and current value !== saved value inside the cookie => revision is not valid
+        if (
+          revision_enabled &&
+          saved_cookie_content["revision"] !== _config.revision
+        ) {
+          valid_revision = false;
+        }
+
+        // If consent is not valid => create consent modal
+        consent_modal_exists = invalid_consent =
+          !cookie_consent_accepted ||
+          !valid_revision ||
+          !consent_date ||
+          !last_consent_update ||
+          !consent_uuid;
+
+        // Generate cookie-settings dom (& consent modal)
+        _createCookieConsentHTML();
+
+        _getModalFocusableData();
+        _guiManager(user_config["gui_options"]);
+        _addDataButtonListeners();
+
+        if (_config.autorun && consent_modal_exists) {
+          _cookieconsent.show(user_config["delay"] || 0);
+        }
+
+        // Add class to enable animations/transitions
+        setTimeout(function () {
+          _addClass(main_container, "c--anim");
+        }, 30);
+
+        // Accessibility :=> if tab pressed => trap focus inside modal
+        setTimeout(function () {
+          _handleFocusTrap();
+        }, 100);
+
+        // If consent is valid
+        if (!invalid_consent) {
+          var rfc_prop_exists =
+            typeof saved_cookie_content["rfc_cookie"] === "boolean";
+
+          /*
+           * Convert cookie to rfc format (if `use_rfc_cookie` is enabled)
+           */
+          if (
+            !rfc_prop_exists ||
+            (rfc_prop_exists &&
+              saved_cookie_content["rfc_cookie"] !== _config.use_rfc_cookie)
+          ) {
+            saved_cookie_content["rfc_cookie"] = _config.use_rfc_cookie;
+            _setCookie(
+              _config.cookie_name,
+              JSON.stringify(saved_cookie_content)
+            );
+          }
+
+          /**
+           * Update accept type
+           */
+          accept_type = _getAcceptType(_getCurrentCategoriesState());
+
+          _manageExistingScripts();
+
+          if (typeof onAccept === "function") onAccept(saved_cookie_content);
+
+          _log(
+            "CookieConsent [NOTICE]: consent already given!",
+            saved_cookie_content
+          );
+        } else {
+          if (_config.mode === "opt-out") {
+            _log(
+              "CookieConsent [CONFIG] mode='" +
+                _config.mode +
+                "', default enabled categories:",
+              default_enabled_categories
+            );
+            _manageExistingScripts(default_enabled_categories);
+          }
+          _log("CookieConsent [NOTICE]: ask for consent!");
+        }
+      } else {
+        _log(
+          "CookieConsent [NOTICE]: cookie consent already attached to body!"
+        );
+      }
+    };
+
+    /**
+     * Show settings modal (with optional delay)
+     * @param {number} delay
+     */
+    _cookieconsent.showSettings = function (delay) {
+      setTimeout(
+        function () {
+          _addClass(html_dom, "show--settings");
+          settings_container.setAttribute("aria-hidden", "false");
+          settings_modal_visible = true;
+
+          /**
+           * Set focus to the first focusable element inside settings modal
+           */
+          setTimeout(function () {
+            // If there is no consent-modal, keep track of the last focused elem.
+            if (!consent_modal_visible) {
+              last_elem_before_modal = document.activeElement;
+            } else {
+              last_consent_modal_btn_focus = document.activeElement;
+            }
+
+            if (settings_modal_focusable.length === 0) return;
+
+            if (settings_modal_focusable[3]) {
+              settings_modal_focusable[3].focus();
+            } else {
+              settings_modal_focusable[0].focus();
+            }
+            current_modal_focusable = settings_modal_focusable;
+          }, 200);
+
+          _log("CookieConsent [SETTINGS]: show settings_modal");
+        },
+        delay > 0 ? delay : 0
+      );
+    };
+
+    /**
+     * This function handles the loading/activation logic of the already
+     * existing scripts based on the current accepted cookie categories
+     *
+     * @param {string[]} [must_enable_categories]
+     */
+    var _manageExistingScripts = function (must_enable_categories) {
+      if (!_config.page_scripts) return;
+
+      // get all the scripts with "cookie-category" attribute
+      var scripts = document.querySelectorAll(
+        "script[" + _config.script_selector + "]"
+      );
+      var accepted_categories =
+        must_enable_categories || saved_cookie_content["categories"] || [];
+
+      /**
+       * Load scripts (sequentially), using a recursive function
+       * which loops through the scripts array
+       * @param {Element[]} scripts scripts to load
+       * @param {number} index current script to load
+       */
+      var _loadScripts = function (scripts, index) {
+        if (index < scripts.length) {
+          var curr_script = scripts[index];
+          var curr_script_category = curr_script.getAttribute(
+            _config.script_selector
+          );
+
+          /**
+           * If current script's category is on the array of categories
+           * accepted by the user => load script
+           */
+          if (_inArray(accepted_categories, curr_script_category) > -1) {
+            curr_script.type = "text/javascript";
+            curr_script.removeAttribute(_config.script_selector);
+
+            // get current script data-src
+            var src = curr_script.getAttribute("data-src");
+
+            // some scripts (like ga) might throw warning if data-src is present
+            src && curr_script.removeAttribute("data-src");
+
+            // create fresh script (with the same code)
+            var fresh_script = _createNode("script");
+            fresh_script.textContent = curr_script.innerHTML;
+
+            // Copy attributes over to the new "revived" script
+            (function (destination, source) {
+              var attributes = source.attributes;
+              var len = attributes.length;
+              for (var i = 0; i < len; i++) {
+                var attr_name = attributes[i].nodeName;
+                destination.setAttribute(
+                  attr_name,
+                  source[attr_name] || source.getAttribute(attr_name)
+                );
+              }
+            })(fresh_script, curr_script);
+
+            // set src (if data-src found)
+            src ? (fresh_script.src = src) : (src = curr_script.src);
+
+            // if script has "src" attribute
+            // try loading it sequentially
+            if (src) {
+              // load script sequentially => the next script will not be loaded
+              // until the current's script onload event triggers
+              if (fresh_script.readyState) {
+                // only required for IE <9
+                fresh_script.onreadystatechange = function () {
+                  if (
+                    fresh_script.readyState === "loaded" ||
+                    fresh_script.readyState === "complete"
+                  ) {
+                    fresh_script.onreadystatechange = null;
+                    _loadScripts(scripts, ++index);
+                  }
+                };
+              } else {
+                // others
+                fresh_script.onload = function () {
+                  fresh_script.onload = null;
+                  _loadScripts(scripts, ++index);
+                };
+              }
+            }
+
+            // Replace current "sleeping" script with the new "revived" one
+            curr_script.parentNode.replaceChild(fresh_script, curr_script);
+
+            /**
+             * If we managed to get here and scr is still set, it means that
+             * the script is loading/loaded sequentially so don't go any further
+             */
+            if (src) return;
+          }
+
+          // Go to next script right away
+          _loadScripts(scripts, ++index);
+        }
+      };
+
+      _loadScripts(scripts, 0);
+    };
+
+    /**
+     * Save custom data inside cookie
+     * @param {object|string} new_data
+     * @param {string} [mode]
+     * @returns {boolean}
+     */
+    var _setCookieData = function (new_data, mode) {
+      var set = false;
+      /**
+       * If mode is 'update':
+       * add/update only the specified props.
+       */
+      if (mode === "update") {
+        cookie_data = _cookieconsent.get("data");
+        var same_type = typeof cookie_data === typeof new_data;
+
+        if (same_type && typeof cookie_data === "object") {
+          !cookie_data && (cookie_data = {});
+
+          for (var prop in new_data) {
+            if (cookie_data[prop] !== new_data[prop]) {
+              cookie_data[prop] = new_data[prop];
+              set = true;
+            }
+          }
+        } else if ((same_type || !cookie_data) && cookie_data !== new_data) {
+          cookie_data = new_data;
+          set = true;
+        }
+      } else {
+        cookie_data = new_data;
+        set = true;
+      }
+
+      if (set) {
+        saved_cookie_content["data"] = cookie_data;
+        _setCookie(_config.cookie_name, JSON.stringify(saved_cookie_content));
+      }
+
+      return set;
+    };
+
+    /**
+     * Helper method to set a variety of fields
+     * @param {string} field
+     * @param {object} data
+     * @returns {boolean}
+     */
+    _cookieconsent.set = function (field, data) {
+      switch (field) {
+        case "data":
+          return _setCookieData(data["value"], data["mode"]);
+        default:
+          return false;
+      }
+    };
+
+    /**
+     * Retrieve data from existing cookie
+     * @param {string} field
+     * @param {string} [cookie_name]
+     * @returns {any}
+     */
+    _cookieconsent.get = function (field, cookie_name) {
+      var cookie = JSON.parse(
+        _getCookie(cookie_name || _config.cookie_name, "one", true) || "{}"
+      );
+
+      return cookie[field];
+    };
+
+    /**
+     * Read current configuration value
+     * @returns {any}
+     */
+    _cookieconsent.getConfig = function (field) {
+      return _config[field] || user_config[field];
+    };
+
+    /**
+     * Obtain accepted and rejected categories
+     * @returns {{accepted: string[], rejected: string[]}}
+     */
+    var _getCurrentCategoriesState = function () {
+      // get accepted categories
+      accepted_categories = saved_cookie_content["categories"] || [];
+
+      // calculate rejected categories (all_categories - accepted_categories)
+      rejected_categories = all_categories.filter(function (category) {
+        return _inArray(accepted_categories, category) === -1;
+      });
+
+      return {
+        accepted: accepted_categories,
+        rejected: rejected_categories,
+      };
+    };
+
+    /**
+     * Calculate "accept type" given current categories state
+     * @param {{accepted: string[], rejected: string[]}} currentCategoriesState
+     * @returns {string}
+     */
+    var _getAcceptType = function (currentCategoriesState) {
+      var type = "custom";
+
+      // number of categories marked as necessary/readonly
+      var necessary_categories_length = readonly_categories.filter(function (
+        readonly
+      ) {
+        return readonly === true;
+      }).length;
+
+      // calculate accept type based on accepted/rejected categories
+      if (currentCategoriesState.accepted.length === all_categories.length)
+        type = "all";
+      else if (
+        currentCategoriesState.accepted.length === necessary_categories_length
+      )
+        type = "necessary";
+
+      return type;
+    };
+
+    /**
+     * @typedef {object} userPreferences
+     * @property {string} accept_type
+     * @property {string[]} accepted_categories
+     * @property {string[]} rejected_categories
+     */
+
+    /**
+     * Retrieve current user preferences (summary)
+     * @returns {userPreferences}
+     */
+    _cookieconsent.getUserPreferences = function () {
+      var currentCategoriesState = _getCurrentCategoriesState();
+      var accept_type = _getAcceptType(currentCategoriesState);
+
+      return {
+        accept_type: accept_type,
+        accepted_categories: currentCategoriesState.accepted,
+        rejected_categories: currentCategoriesState.rejected,
+      };
+    };
+
+    /**
+     * Function which will run after script load
+     * @callback scriptLoaded
+     */
+
+    /**
+     * Dynamically load script (append to head)
+     * @param {string} src
+     * @param {scriptLoaded} callback
+     * @param {object[]} [attrs] Custom attributes
+     */
+    _cookieconsent.loadScript = function (src, callback, attrs) {
+      var function_defined = typeof callback === "function";
+
+      // Load script only if not already loaded
+      if (!document.querySelector('script[src="' + src + '"]')) {
+        var script = _createNode("script");
+
+        // if an array is provided => add custom attributes
+        if (attrs && attrs.length > 0) {
+          for (var i = 0; i < attrs.length; ++i) {
+            attrs[i] &&
+              script.setAttribute(attrs[i]["name"], attrs[i]["value"]);
+          }
+        }
+
+        // if callback function defined => run callback onload
+        if (function_defined) {
+          script.onload = callback;
+        }
+
+        script.src = src;
+
+        /**
+         * Append script to head
+         */
+        document.head.appendChild(script);
+      } else {
+        function_defined && callback();
+      }
+    };
+
+    /**
+     * Manage dynamically loaded scripts: https://github.com/orestbida/cookieconsent/issues/101
+     * If plugin has already run, call this method to enable
+     * the newly added scripts based on currently selected preferences
+     */
+    _cookieconsent.updateScripts = function () {
+      _manageExistingScripts();
+    };
+
+    /**
+     * Show cookie consent modal (with delay parameter)
+     * @param {number} [delay]
+     * @param {boolean} [create_modal] create modal if it doesn't exist
+     */
+    _cookieconsent.show = function (delay, create_modal) {
+      if (create_modal === true) _createConsentModal(_config.current_lang);
+
+      if (consent_modal_exists) {
+        setTimeout(
+          function () {
+            _addClass(html_dom, "show--consent");
+
+            /**
+             * Update attributes/internal statuses
+             */
+            consent_modal.setAttribute("aria-hidden", "false");
+            consent_modal_visible = true;
+
+            setTimeout(function () {
+              last_elem_before_modal = document.activeElement;
+              current_modal_focusable = consent_modal_focusable;
+            }, 200);
+
+            _log("CookieConsent [MODAL]: show consent_modal");
+          },
+          delay > 0 ? delay : create_modal ? 30 : 0
+        );
+      }
+    };
+
+    /**
+     * Hide consent modal
+     */
+    _cookieconsent.hide = function () {
+      if (consent_modal_exists) {
+        _removeClass(html_dom, "show--consent");
+        consent_modal.setAttribute("aria-hidden", "true");
+        consent_modal_visible = false;
+
+        setTimeout(function () {
+          //restore focus to the last page element which had focus before modal opening
+          last_elem_before_modal.focus();
+          current_modal_focusable = null;
+        }, 200);
+
+        _log("CookieConsent [MODAL]: hide");
+      }
+    };
+
+    /**
+     * Hide settings modal
+     */
+    _cookieconsent.hideSettings = function () {
+      _removeClass(html_dom, "show--settings");
+      settings_modal_visible = false;
+      settings_container.setAttribute("aria-hidden", "true");
+
+      setTimeout(function () {
+        /**
+         * If consent modal is visible, focus him (instead of page document)
+         */
+        if (consent_modal_visible) {
+          last_consent_modal_btn_focus && last_consent_modal_btn_focus.focus();
+          current_modal_focusable = consent_modal_focusable;
+        } else {
+          /**
+           * Restore focus to last page element which had focus before modal opening
+           */
+          last_elem_before_modal && last_elem_before_modal.focus();
+          current_modal_focusable = null;
+        }
+
+        clicked_inside_modal = false;
+      }, 200);
+
+      _log("CookieConsent [SETTINGS]: hide settings_modal");
+    };
+
+    /**
+     * Accept cookieconsent function API
+     * @param {string[]|string} _categories - Categories to accept
+     * @param {string[]} [_exclusions] - Excluded categories [optional]
+     */
+    _cookieconsent.accept = function (_categories, _exclusions) {
+      var categories = _categories || undefined;
+      var exclusions = _exclusions || [];
+      var to_accept = [];
+
+      /**
+       * Get all accepted categories
+       * @returns {string[]}
+       */
+      var _getCurrentPreferences = function () {
+        var toggles = document.querySelectorAll(".c-tgl") || [];
+        var states = [];
+
+        for (var i = 0; i < toggles.length; i++) {
+          if (toggles[i].checked) {
+            states.push(toggles[i].value);
+          }
+        }
+        return states;
+      };
+
+      if (!categories) {
+        to_accept = _getCurrentPreferences();
+      } else {
+        if (
+          typeof categories === "object" &&
+          typeof categories.length === "number"
+        ) {
+          for (var i = 0; i < categories.length; i++) {
+            if (_inArray(all_categories, categories[i]) !== -1)
+              to_accept.push(categories[i]);
+          }
+        } else if (typeof categories === "string") {
+          if (categories === "all") to_accept = all_categories.slice();
+          else {
+            if (_inArray(all_categories, categories) !== -1)
+              to_accept.push(categories);
+          }
+        }
+      }
+
+      // Remove excluded categories
+      if (exclusions.length >= 1) {
+        for (i = 0; i < exclusions.length; i++) {
+          to_accept = to_accept.filter(function (item) {
+            return item !== exclusions[i];
+          });
+        }
+      }
+
+      // Add back all the categories set as "readonly/required"
+      for (i = 0; i < all_categories.length; i++) {
+        if (
+          readonly_categories[i] === true &&
+          _inArray(to_accept, all_categories[i]) === -1
+        ) {
+          to_accept.push(all_categories[i]);
+        }
+      }
+
+      _saveCookiePreferences(to_accept);
+    };
+
+    /**
+     * API function to easily erase cookies
+     * @param {(string|string[])} _cookies
+     * @param {string} [_path] - optional
+     * @param {string} [_domain] - optional
+     */
+    _cookieconsent.eraseCookies = function (_cookies, _path, _domain) {
+      var cookies = [];
+      var domains = _domain
+        ? [_domain, "." + _domain]
+        : [_config.cookie_domain, "." + _config.cookie_domain];
+
+      if (typeof _cookies === "object" && _cookies.length > 0) {
+        for (var i = 0; i < _cookies.length; i++) {
+          this.validCookie(_cookies[i]) && cookies.push(_cookies[i]);
+        }
+      } else {
+        this.validCookie(_cookies) && cookies.push(_cookies);
+      }
+
+      _eraseCookies(cookies, _path, domains);
+    };
+
+    /**
+     * Set cookie, by specifying name and value
+     * @param {string} name
+     * @param {string} value
+     */
+    var _setCookie = function (name, value) {
+      var cookie_expiration = _config.cookie_expiration;
+
+      if (
+        typeof _config.cookie_necessary_only_expiration === "number" &&
+        accept_type === "necessary"
+      )
+        cookie_expiration = _config.cookie_necessary_only_expiration;
+
+      value = _config.use_rfc_cookie ? encodeURIComponent(value) : value;
+
+      var date = new Date();
+      date.setTime(date.getTime() + 1000 * (cookie_expiration * 24 * 60 * 60));
+      var expires = "; expires=" + date.toUTCString();
+
+      var cookieStr =
+        name +
+        "=" +
+        (value || "") +
+        expires +
+        "; Path=" +
+        _config.cookie_path +
+        ";";
+      cookieStr += " SameSite=" + _config.cookie_same_site + ";";
+
+      // assures cookie works with localhost (=> don't specify domain if on localhost)
+      if (window.location.hostname.indexOf(".") > -1) {
+        cookieStr += " Domain=" + _config.cookie_domain + ";";
+      }
+
+      if (window.location.protocol === "https:") {
+        cookieStr += " Secure;";
+      }
+
+      document.cookie = cookieStr;
+
+      _log(
+        "CookieConsent [SET_COOKIE]: cookie '" + name + "'=",
+        JSON.parse(value)
+      );
+      _log(
+        "CookieConsent [SET_COOKIE]: '" +
+          name +
+          "' expires after " +
+          cookie_expiration +
+          " day(s)"
+      );
+    };
+
+    /**
+     * Get cookie value by name,
+     * returns the cookie value if found (or an array
+     * of cookies if filter provided), otherwise empty string: ""
+     * @param {string} name
+     * @param {string} filter 'one' or 'all'
+     * @param {boolean} [get_value] set to true to obtain its value
+     * @returns {string|string[]}
+     */
+    var _getCookie = function (name, filter, get_value) {
+      var found;
+
+      if (filter === "one") {
+        found = document.cookie.match("(^|;)\\s*" + name + "\\s*=\\s*([^;]+)");
+        found = found ? (get_value ? found.pop() : name) : "";
+
+        if (found && name === _config.cookie_name) {
+          try {
+            found = JSON.parse(found);
+          } catch (e) {
+            try {
+              found = JSON.parse(decodeURIComponent(found));
+            } catch (e) {
+              // if I got here => cookie value is not a valid json string
+              found = {};
+            }
+          }
+          found = JSON.stringify(found);
+        }
+      } else if (filter === "all") {
+        // array of names of all existing cookies
+        var cookies = document.cookie.split(/;\s*/);
+        found = [];
+        for (var i = 0; i < cookies.length; i++) {
+          found.push(cookies[i].split("=")[0]);
+        }
+      }
+
+      return found;
+    };
+
+    /**
+     * Delete cookie by name & path
+     * @param {string[]} cookies
+     * @param {string} [custom_path] - optional
+     * @param {string[]} domains - example: ['domain.com', '.domain.com']
+     */
+    var _eraseCookies = function (cookies, custom_path, domains) {
+      var path = custom_path ? custom_path : "/";
+      var expires = "Expires=Thu, 01 Jan 1970 00:00:01 GMT;";
+
+      for (var i = 0; i < cookies.length; i++) {
+        for (var j = 0; j < domains.length; j++) {
+          document.cookie =
+            cookies[i] +
+            "=; path=" +
+            path +
+            (domains[j].indexOf(".") > -1 ? "; domain=" + domains[j] : "") +
+            "; " +
+            expires;
+        }
+        _log(
+          "CookieConsent [AUTOCLEAR]: deleting cookie: '" +
+            cookies[i] +
+            "' path: '" +
+            path +
+            "' domain:",
+          domains
+        );
+      }
+    };
+
+    /**
+     * Returns true if cookie was found and has valid value (not empty string)
+     * @param {string} cookie_name
+     * @returns {boolean}
+     */
+    _cookieconsent.validCookie = function (cookie_name) {
+      return _getCookie(cookie_name, "one", true) !== "";
+    };
+
+    /**
+     * Function to run when event is fired
+     * @callback eventFired
+     */
+
+    /**
+     * Add event listener to dom object (cross browser function)
+     * @param {Element} elem
+     * @param {string} event
+     * @param {eventFired} fn
+     * @param {boolean} [isPassive]
+     */
+    var _addEvent = function (elem, event, fn, isPassive) {
+      elem.addEventListener(
+        event,
+        fn,
+        isPassive === true ? { passive: true } : false
+      );
+    };
+
+    /**
+     * Get all prop. keys defined inside object
+     * @param {Object} obj
+     */
+    var _getKeys = function (obj) {
+      if (typeof obj === "object") {
+        return Object.keys(obj);
+      }
+    };
+
+    /**
+     * Append class to the specified dom element
+     * @param {HTMLElement} elem
+     * @param {string} classname
+     */
+    var _addClass = function (elem, classname) {
+      elem.classList.add(classname);
+    };
+
+    /**
+     * Remove specified class from dom element
+     * @param {HTMLElement} elem
+     * @param {string} classname
+     */
+    var _removeClass = function (el, className) {
+      el.classList.remove(className);
+    };
+
+    /**
+     * Check if html element has class
+     * @param {HTMLElement} el
+     * @param {string} className
+     */
+    var _hasClass = function (el, className) {
+      return el.classList.contains(className);
+    };
+
+    return _cookieconsent;
+  };
+
+  var init = "initCookieConsent";
+  /**
+   * Make CookieConsent object accessible globally
+   */
+  if (typeof window !== "undefined" && typeof window[init] !== "function") {
+    window[init] = CookieConsent;
+  }
 })();

--- a/src/cookieconsent.js
+++ b/src/cookieconsent.js
@@ -167,7 +167,12 @@
       /** @type {HTMLElement} */ settings_buttons,
       /** @type {HTMLElement} */ settings_save_btn,
       /** @type {HTMLElement} */ settings_accept_all_btn,
-      /** @type {HTMLElement} */ settings_reject_all_btn;
+      /** @type {HTMLElement} */ settings_reject_all_btn,
+      /** @type {HTMLElement} */ consent_links_imprint,
+      /** @type {HTMLElement} */ consent_links_privacy,
+      /** @type {HTMLElement} */ consent_links,
+      /** @type {HTMLElement} */ privacy_policy_link,
+      /** @type {HTMLElement} */ imprint_link;
 
     /**
      * Update config settings
@@ -592,32 +597,26 @@
       }
 
       // add links to privacy policy and imprint to modal
-      const consent_links = _createNode("div");
+      consent_links = _createNode("div");
       consent_links.id = "c-link";
 
-      const imprint_link =
+      imprint_link =
         user_config.languages[lang]["consent_modal"]["imprint_link"];
       if (imprint_link) {
-        const i_link = imprint_link["url"];
-        const i_text = imprint_link["text"];
-
-        const consent_links_imprint = _createNode("a");
+        consent_links_imprint = _createNode("a");
         consent_links_imprint.classList.add("cc-link");
-        consent_links_imprint.textContent = i_text;
-        consent_links_imprint.setAttribute("href", i_link);
+        consent_links_imprint.textContent = imprint_link["text"];
+        consent_links_imprint.setAttribute("href", imprint_link["url"]);
         consent_links.appendChild(consent_links_imprint);
       }
 
-      const privacy_policy_link =
+      privacy_policy_link =
         user_config.languages[lang]["consent_modal"]["privacy_policy_link"];
       if (privacy_policy_link) {
-        const p_link = privacy_policy_link["url"];
-        const p_text = privacy_policy_link["text"];
-
-        const consent_links_privacy = _createNode("a");
+        consent_links_privacy = _createNode("a");
         consent_links_privacy.classList.add("cc-link");
-        consent_links_privacy.textContent = p_text;
-        consent_links_privacy.setAttribute("href", p_link);
+        consent_links_privacy.textContent = privacy_policy_link["text"];
+        consent_links_privacy.setAttribute("href", privacy_policy_link["url"]);
         consent_links.appendChild(consent_links_privacy);
       }
 


### PR DESCRIPTION
# Adds optional settings for privacy policy and imprint links
- meets the requirement that the link to privacy policy and imprint can be reached with one click
- if parameters are assigned, the elements are automatically generated in the modal 
- all layouts are supported and styled differently: 'bar', 'box', 'cloud'
- mobile view is supported as well

```
languages: {
        en: {
            consent_modal: {
                imprint_link: {
                    text: 'imprint',
                    url: '/imprint.html',
                },
                privacy_policy_link: {
                    text: 'privacy policy',
                    url: '/privacy.html',
                },
            },
         },
};
```

### 'bar' - mobile view
<img width="496" alt="cc_bar_mobile" src="https://user-images.githubusercontent.com/18313993/176236288-d9d04f5e-5e1b-482a-8d63-46dd89646e75.png">

### 'cloud'
<img width="716" alt="cc_cloud" src="https://user-images.githubusercontent.com/18313993/176236297-bc4865ad-b429-4562-8868-b3f612ba36c2.png">

### 'cloud' - mobile view
<img width="421" alt="cc_cloud_mobile" src="https://user-images.githubusercontent.com/18313993/176236300-7e8908fd-ae6e-426e-9c70-223e2efe9e9a.png">


Sorry for the massiv code-shift ... the auto-formatter did this and i did not find any "style guide"
