### PR TITLE
Skip Vercel and CircleCI workflows for v2.x.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,19 @@
+version: 2.1
+
+orbs:
+  node: circleci/node@5.0.2
+
+jobs:
+  skip-build:
+    docker:
+      - image: cimg/node:lts
+    steps:
+      - checkout
+      - run:
+          name: Skip
+          command: circleci-agent step halt
+
+workflows:
+  my-workflow:
+    jobs:
+      - skip-build

--- a/ignore-step.js
+++ b/ignore-step.js
@@ -1,0 +1,6 @@
+/**
+ * Completely skip build in vercel
+ * since v2 doesn't have any docs. to build
+ */
+
+process.exit(0)


### PR DESCRIPTION
Prevent the ugly red mark from appearing in v2.x.x branches.