### PR TITLE
Updated allowedCategory Readme example to be correct

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -463,7 +463,7 @@ Additional methods for an easier management of your scripts and cookie settings 
     Example:
     ```javascript
     // Check if user accepts cookie consent with analytics category enabled
-    if (!cookieconsent.allowedCategory('analytics')) {
+    if (cookieconsent.allowedCategory('analytics')) {
         // yoo, you might want to load analytics.js ...
     };
     ```


### PR DESCRIPTION
We noticed when looking at the README example for allowedCategory, it had a '!' in the if. I don't think this is the correct intention. Might be wrong but if its not then here is a tiny fix! 