### PR TITLE
Fix an error when saving setting with updated categories.

### DIFF
--- a/src/utils/cookies.js
+++ b/src/utils/cookies.js
@@ -125,11 +125,11 @@ export const saveCookiePreferences = () => {
     state._allCategoryNames.forEach(categoryName => {
 
         state._lastChangedServices[categoryName] = arrayDiff(
-            state._enabledServices[categoryName],
+            state._enabledServices[categoryName] || [],
             state._lastEnabledServices[categoryName] || []
         );
 
-        if(state._lastChangedServices[categoryName].length > 0)
+        if(!(categoryName in state._enabledServices) || state._lastChangedServices[categoryName].length > 0)
             servicesWereChanged = true;
     });
 


### PR DESCRIPTION
I noticed that if the initial consent is saved when a single cookie category is defined and you then add a new category without incrementing consent revision (as is typical during development), trying to save the settings in the preferences dialog results in the following error (as reported by Firefox):

```
Uncaught TypeError: arr1 is undefined
    arrayDiff cookieconsent.umd.js:673
    saveCookiePreferences cookieconsent.umd.js:2314
    saveCookiePreferences cookieconsent.umd.js:2312
    acceptCategory cookieconsent.umd.js:2871
    acceptHelper cookieconsent.umd.js:1635
    createPreferencesModal cookieconsent.umd.js:1627
    addEvent cookieconsent.umd.js:569
    createPreferencesModal cookieconsent.umd.js:1626
    addDataButtonListeners cookieconsent.umd.js:742
    addEvent cookieconsent.umd.js:569
    addDataButtonListeners cookieconsent.umd.js:738
    createCookieConsentHTML cookieconsent.umd.js:2066
    run cookieconsent.umd.js:3408
```

This is an attempt to fix it. I wasn't quite sure if the check for `servicesWereChanged` is right, but I thought it would make sense.