### PR TITLE
Added info on how to open modal from javascript

### DIFF
--- a/docs/essential/getting-started.md
+++ b/docs/essential/getting-started.md
@@ -302,3 +302,10 @@ The simplest way to open the preferences modal is by creating a `button` (or a l
 ```
 
 Check out all the possible [data-cc](/advanced/custom-attribute)  values.
+
+NOTE: In some situations (like using multiple components in an Angular application) the data attribute may not work. Using the function showPreferences() will have the same effect.
+
+```typescript
+import * as CookieConsent from 'vanilla-cookieconsent';
+CookieConsent.showPreferences();
+```


### PR DESCRIPTION
There are situations where a data-cc attribute may not be useful nor even work. I added info for users to know there is also a JS method