### PR TITLE
Fix typo in playground de.json

### DIFF
--- a/playground/src/translations/de.json
+++ b/playground/src/translations/de.json
@@ -1,6 +1,6 @@
 {
     "consentModal": {
-        "lable": "Cookie-Zustimmung",
+        "label": "Cookie-Zustimmung",
         "title": "Hallo Reisende, es ist Kekszeit!",
         "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip.",
         "acceptAllBtn": "Alle akzeptieren",


### PR DESCRIPTION
Hi, this fixes a typo in the playground's German translation file.

PS: Nice job with this plugin, especially with the newer version and the playground. Keep it up!