### PR TITLE
GitHub Action to run tests on current version of Node.js

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+# https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+
+name: ci
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+jobs:
+  ci:
+    strategy:
+      matrix:
+        node-version: [16.x, 18.x, 20.x]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm test


### PR DESCRIPTION
The CircleCI job currently does nothing.

https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs

https://github.com/nodejs/release#release-schedule