### PR TITLE
Update cookieconsent.js to not show on Google search

### DIFF
--- a/src/cookieconsent.js
+++ b/src/cookieconsent.js
@@ -993,6 +993,7 @@
             // Create main container which holds both consent modal & settings modal
             main_container = _createNode('div');
             main_container.id = 'cc--main';
+            main_container.setAttribute("data-nosnippet", "true");          
 
             // Fix layout flash
             main_container.style.position = "fixed";


### PR DESCRIPTION
https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag#data-nosnippet-attr

Google Search picks some cookie description, as my website description, instead of the meta tag.
With this patch, it should not be the case any more.

![imagen](https://github.com/orestbida/cookieconsent/assets/10741347/813b6eca-c477-4a04-ba3d-0f0282e654c5)
