### PR TITLE
docs: fix GitHub links (Closes #623)

### DIFF
--- a/docs/advanced/ui-customization.md
+++ b/docs/advanced/ui-customization.md
@@ -39,7 +39,7 @@ document.documentElement.classList.add('cc--darkmode');
 ```
 
 ## Available css variables
-You can develop your own theme by modifying/overriding the available css variables in [/src/scss/abstracts](https://github.com/orestbida/cookieconsent/src/scss/abstracts/).
+You can develop your own theme by modifying/overriding the available css variables in [/src/scss/abstracts](https://github.com/orestbida/cookieconsent/tree/master/src/scss/abstracts).
 
 More css variables:
 

--- a/docs/essential/getting-started.md
+++ b/docs/essential/getting-started.md
@@ -426,7 +426,7 @@ You should now see the consent modal pop up!
 You can also define [external translation files](/advanced/language-configuration.html#external-translations).
 :::
 
-If you're having trouble setting up the plugin, you can check out a few [demo examples](https://github.com/orestbida/cookieconsent/demo) on github.
+If you're having trouble setting up the plugin, you can check out a few [demo examples](https://github.com/orestbida/cookieconsent/tree/master/demo) on github.
 
 <br>
 


### PR DESCRIPTION
Hi, there are few broken links in the documentation.

