### PR TITLE
fix: unhandled exception when category is unknown

### DIFF
--- a/src/core/api.js
+++ b/src/core/api.js
@@ -129,7 +129,7 @@ export const acceptService = (service, category) => {
  */
 export const acceptedService = (service, category) => {
     const acceptedServices = !globalObj._state._invalidConsent
-        ? globalObj._state._acceptedServices[category]
+        ? (globalObj._state._acceptedServices[category] || [])
         : [];
 
     return elContains(acceptedServices, service);


### PR DESCRIPTION
The small change prevents passing undefined to a function that expects an Array by providing a fallback.