### PR TITLE
Fix service reject issue & setCookieData() method deletes lastConsentTimestamp field

### DIFF
--- a/src/core/api.js
+++ b/src/core/api.js
@@ -614,12 +614,12 @@ const retrieveState = () => {
      * and calculate acceptType
      */
     if (!state._invalidConsent) {
-        state._enabledServices = {...state._acceptedServices};
-
         state._acceptedServices = {
             ...state._acceptedServices,
             ...services
         };
+
+        state._enabledServices = {...state._acceptedServices};
 
         setAcceptedCategories([
             ...state._readOnlyCategories,

--- a/src/utils/cookies.js
+++ b/src/utils/cookies.js
@@ -168,6 +168,10 @@ export const saveCookiePreferences = () => {
         consentId: state._consentId,
         services: deepCopy(state._acceptedServices)
     };
+	
+    if (state._lastConsentTimestamp) {
+        state._savedCookieContent.lastConsentTimestamp = state._lastConsentTimestamp.toISOString();
+    }
 
     let isFirstConsent = false;
     const stateChanged = categoriesWereChanged || servicesWereChanged;


### PR DESCRIPTION
Fixes #700

The retrieveState method of api.js currently sets the _enabledServices before _acceptedServices so the enabled services don't include services read from the cc-cookie. I think reversing this order is sufficient to fix it.

Fixes #702

The setCookieData() method can accidentally delete the lastConsentTimestamp field from the cc-cookie.