### PR TITLE
Expose the event that triggered onModalShow/onModalHide callback function

### DIFF
--- a/src/core/api.js
+++ b/src/core/api.js
@@ -253,7 +253,7 @@ export const hide = () => {
 /**
  * Show preferences modal
  */
-export const showPreferences = () => {
+export const showPreferences = (event) => {
     const state = globalObj._state;
 
     if (state._preferencesModalVisible)
@@ -285,7 +285,7 @@ export const showPreferences = () => {
 
     debug('CookieConsent [TOGGLE]: show preferencesModal');
 
-    fireEvent(globalObj._customEvents._onModalShow, PREFERENCES_MODAL_NAME);
+    fireEvent(globalObj._customEvents._onModalShow, PREFERENCES_MODAL_NAME, undefined, event);
 };
 
 /**
@@ -322,7 +322,7 @@ const discardUnsavedPreferences = () => {
 /**
  * Hide preferences modal
  */
-export const hidePreferences = () => {
+export const hidePreferences = (event) => {
     const state = globalObj._state;
 
     if (!state._preferencesModalVisible)
@@ -356,7 +356,7 @@ export const hidePreferences = () => {
 
     debug('CookieConsent [TOGGLE]: hide preferencesModal');
 
-    fireEvent(globalObj._customEvents._onModalHide, PREFERENCES_MODAL_NAME);
+    fireEvent(globalObj._customEvents._onModalHide, PREFERENCES_MODAL_NAME, undefined, event);
 };
 
 var miniAPI = {

--- a/src/core/modals/preferencesModal.js
+++ b/src/core/modals/preferencesModal.js
@@ -98,7 +98,7 @@ export const createPreferencesModal = (api, createMainContainer) => {
         // Hide preferences on 'esc' key press
         addEvent(dom._htmlDom, 'keydown', (event) => {
             if (event.keyCode === 27)
-                hidePreferences();
+                hidePreferences(event);
         }, true);
 
         dom._pmHeader = createNode(DIV_TAG);

--- a/src/utils/general.js
+++ b/src/utils/general.js
@@ -639,7 +639,7 @@ export const addDataButtonListeners = (elem, api, createPreferencesModal, create
     const acceptAction = (event, acceptType) => {
         preventDefault(event);
         acceptCategory(acceptType);
-        hidePreferences();
+        hidePreferences(event);
         hide();
     };
 
@@ -656,7 +656,7 @@ export const addDataButtonListeners = (elem, api, createPreferencesModal, create
         setAttribute(el, 'aria-haspopup', 'dialog');
         addEvent(el, CLICK_EVENT, (event) => {
             preventDefault(event);
-            showPreferences();
+            showPreferences(event);
         });
 
         if (createPreferencesModalOnHover) {
@@ -900,8 +900,9 @@ export const getModalFocusableData = (modalId) => {
  * @param {string} eventName
  * @param {string} [modalName]
  * @param {HTMLElement} [modal]
+ * @param {event} [Event]
  */
-export const fireEvent = (eventName, modalName, modal) => {
+export const fireEvent = (eventName, modalName, modal, event) => {
     const {
         _onChange,
         _onConsent,
@@ -918,9 +919,9 @@ export const fireEvent = (eventName, modalName, modal) => {
         const modalParams = { modalName };
 
         if (eventName === events._onModalShow) {
-            isFunction(_onModalShow) && _onModalShow(modalParams);
+            isFunction(_onModalShow) && _onModalShow(modalParams, event);
         } else if (eventName === events._onModalHide) {
-            isFunction(_onModalHide) && _onModalHide(modalParams);
+            isFunction(_onModalHide) && _onModalHide(modalParams, event);
         } else {
             modalParams.modal = modal;
             isFunction(_onModalReady) && _onModalReady(modalParams);


### PR DESCRIPTION
When using the onModalShow() callback function it can be useful to know what triggered it. An easy way to achieve this is to expose the event that triggered the callback allowing us to check the event.target or other info.

In my case I wanted to auto-expand a third party services section if it was opened from a static button using: data-cc='show-preferencesModal', but not if it was opened from the button in the standard consent modal. I've put together a quick StackBlitz to show this in action: [https://stackblitz.com/edit/stackblitz-starters-9caf9y?file=index.js](https://stackblitz.com/edit/stackblitz-starters-9caf9y?file=index.js)

Hopefully you agree that this would be a useful addition.