### PR TITLE
Add exported performAutoclearCookies function

### DIFF
--- a/src/core/api.js
+++ b/src/core/api.js
@@ -143,7 +143,7 @@ export const acceptedService = (service, category) => {
 export const validCookie = (cookieName) => getSingleCookie(cookieName, true) !== '';
 
 /**
- * Perform clear of cookies for disabled categories
+ * Perform clear of cookies for disabled categories and services using the autoClear configuration
  */
 export const performAutoclearCookies = () => {
     // Pretend it was our first consent, so the autoclear deletes any disabled category cookies

--- a/src/core/api.js
+++ b/src/core/api.js
@@ -52,6 +52,7 @@ import {
 
 import {
     setCookie,
+    autoclearCookiesHelper,
     eraseCookiesHelper,
     saveCookiePreferences,
     getSingleCookie,
@@ -140,6 +141,14 @@ export const acceptedService = (service, category) => {
  * @param {string} cookieName
  */
 export const validCookie = (cookieName) => getSingleCookie(cookieName, true) !== '';
+
+/**
+ * Perform clear of cookies for disabled categories
+ */
+export const clearDisabledCategoryCookies = () => {
+    // Pretend it was our first consent, so the autoclear deletes any disabled category cookies
+    autoclearCookiesHelper(true)
+};
 
 /**
  * Erase cookies API

--- a/src/core/api.js
+++ b/src/core/api.js
@@ -145,7 +145,7 @@ export const validCookie = (cookieName) => getSingleCookie(cookieName, true) !==
 /**
  * Perform clear of cookies for disabled categories
  */
-export const clearDisabledCategoryCookies = () => {
+export const performAutoclearCookies = () => {
     // Pretend it was our first consent, so the autoclear deletes any disabled category cookies
     autoclearCookiesHelper(true)
 };

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -183,6 +183,12 @@ describe("API tests", () => {
         expect(api.validCookie('test_cookie5')).toBe(false);
     });
 
+    it('Should erase cookie by autoClear', () => {
+        document.cookie = 'test_cookie=21; expires=Sun, 1 Jan 2063 00:00:00 UTC; path=/';
+        api.performAutoclearCookies();
+        expect(api.validCookie('test_cookie')).toBe(false);
+    })
+
     it('Should show the consent modal', async () => {
         api.reset(true);
         testConfig.autoShow = false;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -616,6 +616,11 @@ declare namespace CookieConsent {
     function eraseCookies(cookies: string | RegExp | (string|RegExp)[], path?: string, domain?: string): void
 
     /**
+     * Perform clear of cookies for disabled categories and services using the autoClear configuration
+     */
+    function performAutoclearCookies(): void
+
+    /**
      * Load '.js' files.
      * @param src Path pointing to the js file
      * @param attributes Attributes added to the script


### PR DESCRIPTION
This PR borrows the functionality of the `autoclearCookiesHelper` to re-remove cookies that are managed by cookieconsent autoClear configuration, without needing to cause a change in the accepted services or categories.