### PR TITLE
docs: add missing bar 'top' position option

### DIFF
--- a/docs/reference/configuration-reference.md
+++ b/docs/reference/configuration-reference.md
@@ -431,7 +431,7 @@ Tweak main UI settings.
     | ------- | ---------------- | ------------------------- | ------------------------- |
     | `box`   | `wide`, `inline` | `top`, `middle`, `bottom` | `left`, `center`, `right` |
     | `cloud` | `inline`         | `top`, `middle`, `bottom` | `left`, `center`, `right` |
-    | `bar `  | `inline`         | `bottom`                  | -                         |
+    | `bar `  | `inline`         | `top`, `bottom`           | -                         |
 
     ::: warning Note
     Valid `layout` syntax: `<layoutName> <layoutVariant>`. <br>


### PR DESCRIPTION
Bar has also a valid Y position option 'top', which is also offered in the playground: https://playground.cookieconsent.orestbida.com/

... but this is inconsistent with the docs, where this option is missing.