### PR TITLE
Docs: add missing bar 'top' position option

### DIFF
--- a/docs/reference/configuration-reference.md
+++ b/docs/reference/configuration-reference.md
@@ -431,7 +431,7 @@ Tweak main UI settings.
     | ------- | ---------------- | ------------------------- | ------------------------- |
     | `box`   | `wide`, `inline` | `top`, `middle`, `bottom` | `left`, `center`, `right` |
     | `cloud` | `inline`         | `top`, `middle`, `bottom` | `left`, `center`, `right` |
-    | `bar `  | `inline`         | `bottom`                  | -                         |
+    | `bar `  | `inline`         | `top`, `bottom`           | -                         |
 
     ::: warning Note
     Valid `layout` syntax: `<layoutName> <layoutVariant>`. <br>


### PR DESCRIPTION
Bar has also a valid Y position option 'top', which is also offered in the playground: https://playground.cookieconsent.orestbida.com/

![image](https://github.com/user-attachments/assets/d88f72b8-6d48-43c0-8230-184ba5132c04)

But this is inconsistent with the docs, where this option is missing.