### PR TITLE
feat: store language code of the consent in the cookie

### DIFF
--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -343,6 +343,7 @@ Returns the plugin's own cookie, or just one of the fields.
         consentId: string
         consentTimestamp: string,
         lastConsentTimestamp: string,
+        languageCode: string,
         services: {[key: string]: string[]}
     }
     ```

--- a/src/utils/cookies.js
+++ b/src/utils/cookies.js
@@ -166,9 +166,10 @@ export const saveCookiePreferences = () => {
         data: state._cookieData,
         consentTimestamp: state._consentTimestamp.toISOString(),
         consentId: state._consentId,
-        services: deepCopy(state._acceptedServices)
+        services: deepCopy(state._acceptedServices),
+        languageCode: globalObj._state._currentLanguageCode
     };
-	
+
     if (state._lastConsentTimestamp) {
         state._savedCookieContent.lastConsentTimestamp = state._lastConsentTimestamp.toISOString();
     }

--- a/tests/cookies.test.js
+++ b/tests/cookies.test.js
@@ -32,6 +32,7 @@ describe("Cookie should be created successfully", () => {
         expect(typeof ccCookie.consentId).toBe('string');
         expect(ccCookie.consentTimestamp).toBeDefined();
         expect(ccCookie.lastConsentTimestamp).toBeDefined();
+        expect(ccCookie.languageCode).toEqual('en');
         expect(ccCookie.categories).toEqual(['necessary', 'analytics', 'ads']);
         expect(ccCookie.services).toMatchObject({
             necessary: ['service1'],

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -176,6 +176,11 @@ declare namespace CookieConsent {
         lastConsentTimestamp: string
 
         /**
+         * Language code of the consent.
+         */
+        languageCode: string
+
+        /**
          * All enabled services.
          */
         services: {[key: string]: string[]}
@@ -214,10 +219,10 @@ declare namespace CookieConsent {
          * @default 'Lax'
          */
         sameSite?: 'Lax' | 'Strict' | 'None'
-        
+
         /**
          * Cookie secure flag.
-         * 
+         *
          * @default true
          */
         secure?: boolean


### PR DESCRIPTION
We use cookieconsent library with many languages on multi-lingual site. Because of that, is it important information for us to be able to know the language of the consent the user has given.

This is useful in callbacks (as we store the consent meta data including language also server-side) and also when reading the language code from the already given consent cookie.

This PR extends cookie data with languageCode property. The property is only stored in the cookie, and its use is completely up to library users - its not populated back to cookieconsent global state etc.