### PR TITLE
Removes the unnecessary aria-hidden="false" attribute from the dialog component

### DIFF
--- a/src/core/modals/consentModal.js
+++ b/src/core/modals/consentModal.js
@@ -94,7 +94,7 @@ export const createConsentModal = (api, createMainContainer) => {
 
         setAttribute(dom._cm, 'role', 'dialog');
         setAttribute(dom._cm, 'aria-modal', 'true');
-        setAttribute(dom._cm, ARIA_HIDDEN, 'false');
+        setAttribute(dom._cm, ARIA_HIDDEN, undefined);
         setAttribute(dom._cm, 'aria-describedby', 'cm__desc');
 
         if (consentModalLabelValue)

--- a/src/core/modals/preferencesModal.js
+++ b/src/core/modals/preferencesModal.js
@@ -315,7 +315,7 @@ export const createPreferencesModal = (api, createMainContainer) => {
                     if (!hasClass(section, 'is-expanded')) {
                         addClass(section, 'is-expanded');
                         setAttribute(btn, 'aria-expanded', 'true');
-                        setAttribute(accordion, ARIA_HIDDEN, 'false');
+                        setAttribute(accordion, ARIA_HIDDEN, undefined);
                     } else {
                         removeClass(section, 'is-expanded');
                         setAttribute(btn, 'aria-expanded', 'false');

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -210,7 +210,7 @@ describe("API tests", () => {
         await api.run(testConfig)
         api.show();
         expect(htmlHasClass(consentModalClassToggle)).toBe(true);
-        expect(globalObj._dom._cm.getAttribute('aria-hidden')).toBe('false');
+        expect(globalObj._dom._cm.getAttribute('aria-hidden')).not.toBeDefined();
     })
 
     it('Should hide the consent modal', async () => {


### PR DESCRIPTION
### Summary
This PR removes the unnecessary aria-hidden="false" attribute from the dialog component.

### Context
The current dialog markup contains:

```html
<div class="cm cm--cloud cm--inline cm--bottom cm--right" role="dialog" aria-modal="true" aria-hidden="false" aria-describedby="cm__desc" aria-labelledby="cm__title">
```

According to the W3C specification, the use of `aria-hidden="false"` is no longer supported. It may cause **warnings in accessibility testing tools** and lead to inconsistent behavior across browsers.

### W3C Reference:

> “The original intent for aria-hidden="false" was to allow user agents to expose content that was otherwise hidden from the accessibility tree. However, due to ambiguity in the specification and inconsistent browser support for the false value, the original intent is no longer supported.”

### Change

- Removed aria-hidden="false" from the dialog element.

### Benefit

- Prevents accessibility warnings in audits.
- Ensures compliance with current W3C specifications.
- Improves overall accessibility consistency.