### PR TITLE
Improved WebComponents Support

### DIFF
--- a/playground/src/styles/global.scss
+++ b/playground/src/styles/global.scss
@@ -17,7 +17,7 @@ html{
     text-size-adjust: none;
 }
 
-:root{
+:root, :host {
     --d-gap: .625rem;
     --d-border-radius: .375rem;
     --d-select-height: 2.25rem;

--- a/src/core/api.js
+++ b/src/core/api.js
@@ -203,7 +203,7 @@ export const show = (createModal) => {
 
     focusAfterTransition(_dom._cm, 1);
 
-    addClass(_dom._htmlDom, TOGGLE_CONSENT_MODAL_CLASS);
+    addClass(_dom._rootEl, TOGGLE_CONSENT_MODAL_CLASS);
     removeAttribute(_dom._cm, ARIA_HIDDEN);
     /**
      * Set focus to consentModal and enable transition
@@ -237,7 +237,7 @@ export const hide = () => {
      */
     focus(_dom._focusSpan, true);
 
-    removeClass(_dom._htmlDom, TOGGLE_CONSENT_MODAL_CLASS);
+    removeClass(_dom._rootEl, TOGGLE_CONSENT_MODAL_CLASS);
     setAttribute(_dom._cm, ARIA_HIDDEN, 'true');
 
     /**
@@ -245,7 +245,7 @@ export const hide = () => {
      */
     focus(_state._lastFocusedElemBeforeModal);
     _state._lastFocusedElemBeforeModal = null;
-    
+
     /**
      * Remove transition class after it executed
      */
@@ -279,7 +279,7 @@ export const showPreferences = () => {
 
     focusAfterTransition(globalObj._dom._pm, 2);
 
-    addClass(globalObj._dom._htmlDom, TOGGLE_PREFERENCES_MODAL_CLASS);
+    addClass(globalObj._dom._rootEl, TOGGLE_PREFERENCES_MODAL_CLASS);
     removeAttribute(globalObj._dom._pm, ARIA_HIDDEN);
 
     /**
@@ -343,7 +343,7 @@ export const hidePreferences = () => {
      */
     focus(globalObj._dom._pmFocusSpan, true);
 
-    removeClass(globalObj._dom._htmlDom, TOGGLE_PREFERENCES_MODAL_CLASS);
+    removeClass(globalObj._dom._rootEl, TOGGLE_PREFERENCES_MODAL_CLASS);
     setAttribute(globalObj._dom._pm, ARIA_HIDDEN, 'true');
 
     /**
@@ -693,7 +693,7 @@ export const run = async (userConfig) => {
  */
 export const reset = (deleteCookie) => {
     //{{START: GUI}}
-    const { _ccMain, _htmlDom } = globalObj._dom;
+    const { _ccMain } = globalObj._dom;
     //{{END: GUI}}
 
     const { name, path, domain, useLocalStorage } = globalObj._config.cookie;
@@ -720,7 +720,8 @@ export const reset = (deleteCookie) => {
     /**
      * Remove any remaining classes
      */
-    _htmlDom && _htmlDom.classList.remove(
+    const parentEl = globalObj._dom._rootEl;
+    parentEl && parentEl.classList.remove(
         TOGGLE_DISABLE_INTERACTION_CLASS,
         TOGGLE_PREFERENCES_MODAL_CLASS,
         TOGGLE_CONSENT_MODAL_CLASS

--- a/src/core/config-init.js
+++ b/src/core/config-init.js
@@ -1,5 +1,5 @@
 import { globalObj } from './global';
-import { debug, getKeys, isObject, retrieveScriptElements, fetchCategoriesAndServices } from '../utils/general';
+import { debug, getKeys, isObject, isString, retrieveScriptElements, fetchCategoriesAndServices } from '../utils/general';
 import { OPT_OUT_MODE } from '../utils/constants';
 import { resolveCurrentLanguageCode, setCurrentLanguageCode } from '../utils/language';
 
@@ -29,6 +29,8 @@ export const setConfig = (userConfig) => {
     _dom._document = doc;
     //{{START: GUI}}
     _dom._htmlDom = doc.documentElement;
+    const _root = userConfig.root;
+    _dom._rootEl = (_root && isString(_root) ? doc.querySelector(_root) : _root) || doc.documentElement;
     //{{END: GUI}}
     cookie.domain = location.hostname;
 

--- a/src/core/modals/index.js
+++ b/src/core/modals/index.js
@@ -1,5 +1,5 @@
 import { globalObj } from '../global';
-import { createNode, isString, addDataButtonListeners } from '../../utils/general';
+import { createNode, addDataButtonListeners } from '../../utils/general';
 import { createConsentModal } from './consentModal';
 import { createPreferencesModal } from './preferencesModal';
 import { DIV_TAG } from '../../utils/constants';
@@ -16,13 +16,8 @@ export const createMainContainer = () => {
 
     handleRtlLanguage();
 
-    let root = globalObj._state._userConfig.root;
-
-    if (root && isString(root))
-        root = document.querySelector(root);
-
     // Append main container to dom
-    (root || dom._document.body).appendChild(dom._ccMain);
+    dom._rootEl.appendChild(dom._ccMain);
 };
 
 /**

--- a/src/scss/abstracts/_light-color-scheme.scss
+++ b/src/scss/abstracts/_light-color-scheme.scss
@@ -1,5 +1,5 @@
 /** Light color-scheme **/
-:root{
+:root, :host {
     --cc-bg: #ffffff;
     --cc-primary-color: #2c2f31;
     --cc-secondary-color: #5e6266;

--- a/src/scss/core/_base.scss
+++ b/src/scss/core/_base.scss
@@ -5,7 +5,7 @@
  * Global styles/variables
  */
 
-:root{
+:root, :host {
     --cc-font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
     --cc-modal-border-radius: .5rem;
     --cc-btn-border-radius: .4rem;

--- a/src/scss/core/components/_preferences-modal.scss
+++ b/src/scss/core/components/_preferences-modal.scss
@@ -11,7 +11,7 @@ $service-toggle-knob-height: 19px;
 $service-toggle-knob-width: 42px;
 $service-toggle-knob-icon-width: 1.7px;
 
-:root{
+:root, :host {
     --cc-pm-toggle-border-radius: 4em;
 }
 

--- a/src/utils/general.js
+++ b/src/utils/general.js
@@ -772,10 +772,10 @@ export const toggleDisableInteraction = (enable) => {
     clearTimeout(disableInteractionTimeout);
 
     if (enable) {
-        addClass(globalObj._dom._htmlDom, TOGGLE_DISABLE_INTERACTION_CLASS);
+        addClass(globalObj._dom._rootEl, TOGGLE_DISABLE_INTERACTION_CLASS);
     }else {
         disableInteractionTimeout = setTimeout(() => {
-            removeClass(globalObj._dom._htmlDom, TOGGLE_DISABLE_INTERACTION_CLASS);
+            removeClass(globalObj._dom._rootEl, TOGGLE_DISABLE_INTERACTION_CLASS);
         }, 500);
     }
 };

--- a/tests/config/mocks-utils.js
+++ b/tests/config/mocks-utils.js
@@ -1,3 +1,5 @@
+import { globalObj } from '../../src/core/global';
+
 export const botUserAgent = 'Mozilla/5.0 (Linux; Android 5.0; SM-G920A) AppleWebKit (KHTML, like Gecko) Chrome Mobile Safari (compatible; AdsBot-Google-Mobile; +http://www.google.com/mobile/adsbot.html)';
 
 export const setCookie = (name, value, days = 1) => {
@@ -8,7 +10,7 @@ export const setCookie = (name, value, days = 1) => {
 }
 
 export function htmlHasClass(className) {
-    return document.documentElement.className.includes(className);
+    return globalObj._dom._rootEl.className.includes(className);
 }
 
 export function setUserAgent(userAgent) {


### PR DESCRIPTION
Resolves #817 

Great project, I would love to contribute :)

I've noticed some issues when using this project with [WebComponents](https://developer.mozilla.org/en-US/docs/Web/API/Web_components) mainly [lit](https://lit.dev/docs/) and I've tried to extend the project to improve support for those.

Issues that I'm attempting to solve:
- the CSS classes to toggle the visibility of the modal got appended to the `documentElement`, I suspect that because of [Shadow DOM](https://developer.mozilla.org/en-US/docs/Web/API/Web_components#shadow_dom_2) the modal didn't display -> those classes could be toggled on the root element in the user config
- Shadow DOM requires variables to be instantiated using the `:host` selector