### PR TITLE
fix: remove deprecated overflow-y:overlay in .pm__body

### DIFF
--- a/src/scss/core/components/_preferences-modal.scss
+++ b/src/scss/core/components/_preferences-modal.scss
@@ -98,7 +98,6 @@ $service-toggle-knob-icon-width: 1.7px;
     .pm__body{
         flex: 1;
         overflow-y: auto;
-        overflow-y: overlay;
     }
 
     .pm__section,


### PR DESCRIPTION
## Problem

`.pm__body` in the preferences modal has:

```scss
overflow-y: auto;
overflow-y: overlay;
```

`overflow-y: overlay` is a non-standard, deprecated value that was originally a Chrome/WebKit extension to render the scrollbar on top of content (overlay scrollbars) rather than taking up layout space. It was **removed in Chrome 112** (April 2023) and has never been part of any CSS spec.

In Chrome 112+ and all other engines (Firefox, Safari) the `overlay` line is silently ignored, making it dead code. It also generates console warnings in some tooling.

Closes #784.

## Fix

Remove the dead `overflow-y: overlay` line from `_preferences-modal.scss` and all compiled dist outputs (`cookieconsent.css`, `cookieconsent.esm.js`, `cookieconsent.umd.js`, `preferences-modal.css`).

The `overflow-y: auto` declaration immediately above it already provides the correct scrolling behaviour on all browsers.
