### PR TITLE
fix(core): initialise _dom outside the GUI block so the core build can run

### DIFF
--- a/src/core/global.js
+++ b/src/core/global.js
@@ -306,18 +306,19 @@ export class GlobalState {
             _allScriptTags: []
         };
 
-        //{{START: GUI}}
-
         /**
-         * Pointers to main dom elements
+         * Pointers to main dom elements.
+         *
+         * Not inside a `{{GUI}}` block: the core build strips those, but
+         * `config-init.js` and `utils/general.js` write `_dom._document` and
+         * `_dom._serviceCheckboxInputs[category]` unconditionally, so the
+         * object and these two maps must exist in both builds.
          * @type {DomElements}
          */
         this._dom = {
             _categoryCheckboxInputs: {},
             _serviceCheckboxInputs: {}
         };
-
-        //{{END: GUI}}
 
         /**
          * Callback functions


### PR DESCRIPTION
The `dist/core` build throws as soon as `run()` is called, so it cannot be used at all:

```
TypeError: Cannot set properties of undefined (setting '_document')
```

## What happens

`GlobalState` initialises `this._dom` inside a `//{{START: GUI}} ... //{{END: GUI}}` block in `src/core/global.js`, so `rollup-core.config.mjs` strips it. Two writes to that same object sit outside any GUI block and survive into the core bundle:

* `src/core/config-init.js:29` sets `_dom._document = doc;`
* `src/utils/general.js:191` sets `globalObj._dom._serviceCheckboxInputs[categoryName] = {};`

The first one throws immediately. Fixing only that surfaces the second right behind it, with `TypeError: Cannot set properties of undefined (setting 'necessary')`, so both maps need to exist in the core build as well.

## The change

Move the `this._dom = { ... }` initialiser out of the GUI block. The two maps stay declared and are simply never populated in the core build, which is what their readers already handle: `src/utils/general.js:428-429` both fall back with `|| {}`.

## Verification

I built both bundles from source at `8596c79`, once before and once after the change.

| | `dist/core` `run()` | `dist/cookieconsent.esm.js` |
| --- | --- | --- |
| before | throws | works |
| after | works | byte-identical to before |

The full build coming out byte-identical was the part I most wanted to confirm, since it means existing users cannot be affected.

I then exercised the whole exported API of the fixed core build in Node, with a minimal `document` and `navigator` shim (no DOM needed, it is the UI-less build): `run`, `acceptCategory`, `acceptedCategory`, `acceptService`, `acceptedService`, `getCookie`, `getConfig`, `getUserPreferences`, `validConsent`, `validCookie`, `setCookieData`, `eraseCookies` and `reset`, plus three lifecycles that matter in practice: reset followed by a fresh `run()`, a reload with an existing consent cookie, and `opt-out` mode. All 22 steps pass after the change; four of them throw before it.

```
run() succeeded
  validConsent: true
  categories  : ["necessary","analytics"]
  revision    : 1
  consentId   : present
```

Finally I dropped the rebuilt core into a real Next.js application that uses this library for its logic with a custom React interface, and ran the full consent flow in a browser: first visit, accept all, withdraw, decide again. Cookies, categories, revision and the consent record all behaved correctly, with no console errors.

`pnpm test` still reports 119 passed across 9 suites.

## Notes

This touches `src/` only. I left `dist/` for you to regenerate at release time, matching what #825 did.

The core build has no test coverage at the moment, which is presumably why this went unnoticed. I can add a smoke test that imports `dist/core` after a build step, either here or as a follow-up, but I did not want to change your test setup unasked.

I ran into this while using the library for its logic with a custom React interface on top. `dist/core` is exactly the right artifact for that, which is why fixing it seemed more useful than working around it.
