### PR TITLE
fix: respect lazyHtmlGeneration for consent modal

### DIFF
--- a/src/core/api.js
+++ b/src/core/api.js
@@ -186,7 +186,7 @@ export const show = (createModal) => {
         return;
 
     if (!_state._consentModalExists) {
-        if (createModal) {
+        if (createModal || _state._invalidConsent) {
             createConsentModal(miniAPI, createMainContainer);
         } else {
             return;

--- a/src/core/modals/index.js
+++ b/src/core/modals/index.js
@@ -26,7 +26,7 @@ export const createMainContainer = () => {
 export const generateHtml = (api) => {
     addDataButtonListeners(null, api, createPreferencesModal, createMainContainer);
 
-    if (globalObj._state._invalidConsent)
+    if (globalObj._state._invalidConsent && !globalObj._config.lazyHtmlGeneration)
         createConsentModal(api, createMainContainer);
 
     if (!globalObj._config.lazyHtmlGeneration)

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -42,6 +42,30 @@ describe("Check modals' html generation under different settings", () => {
         expect(htmlHasClass('show--consent')).toBe(false);
     })
 
+    it('Should not generate consent modal markup when autoShow=false and lazyHtmlGeneration=true', async () => {
+        const prevAutoShow = testConfig.autoShow;
+        const prevLazyHtmlGeneration = testConfig.lazyHtmlGeneration;
+
+        try {
+            api.eraseCookies('cc_cookie');
+            testConfig.autoShow = false;
+            testConfig.lazyHtmlGeneration = true;
+            await api.run(testConfig);
+
+            expect(api.validConsent()).toBe(false);
+            expect(htmlHasClass('show--consent')).toBe(false);
+            expect(document.querySelector('#cc-main .cm')).toBeNull();
+
+            api.show();
+
+            expect(document.querySelector('#cc-main .cm')).toBeInstanceOf(HTMLElement);
+            expect(htmlHasClass('show--consent')).toBe(true);
+        } finally {
+            testConfig.autoShow = prevAutoShow;
+            testConfig.lazyHtmlGeneration = prevLazyHtmlGeneration;
+        }
+    })
+
     it('Plugin should stop if bot is detected', async () => {
         setUserAgent(botUserAgent);
         testConfig.hideFromBots = true;


### PR DESCRIPTION
`lazyHtmlGeneration` is documented as delaying modal markup until a modal is about to become visible, but `generateHtml` always built the consent modal whenever consent was invalid. With `autoShow: false` that left an unused `role="dialog"` in the document.

Gate `createConsentModal` on `lazyHtmlGeneration` the same way as the preferences modal. `show()` still creates the consent modal when consent is invalid, so `CookieConsent.show()` continues to work.

Credits @okadriu for the report and the named `generateHtml` path.

Fixes #830
