### PR TITLE
Prevent modal focus from scrolling the host page

### DIFF
--- a/src/utils/general.js
+++ b/src/utils/general.js
@@ -714,7 +714,17 @@ export const focus = (el, toggleTabIndex) => {
      */
     toggleTabIndex && (el.tabIndex = -1);
 
-    el.focus();
+    // Internal modal elements can scroll the host page before the modal CSS loads.
+    if (el.closest && el.closest('#cc-main')) {
+        try {
+            el.focus({preventScroll: true});
+        } catch {
+            // Older browsers may not support focus options.
+            el.focus();
+        }
+    } else {
+        el.focus();
+    }
 
     /**
      * Remove the `tabindex` attribute so

--- a/tests/general.test.js
+++ b/tests/general.test.js
@@ -11,7 +11,8 @@ import {
     elContains,
     arrayDiff,
     deepCopy,
-    uuidv4
+    uuidv4,
+    focus
 } from '../src/utils/general';
 
 import * as CookieConsent from "../src/index"
@@ -132,5 +133,50 @@ describe("Array/Object tests", () => {
         }
 
         expect(deepCopy(original)).toEqual(original);
+    });
+})
+
+describe("Focus behavior", () => {
+    it("Prevents host-page scrolling when focusing CookieConsent elements", () => {
+        const ccMain = createNode('div');
+        const element = createNode('span');
+        ccMain.id = 'cc-main';
+        appendChild(ccMain, element);
+        appendChild(document.body, ccMain);
+        const focusSpy = jest.spyOn(element, 'focus');
+
+        focus(element, true);
+
+        expect(focusSpy).toHaveBeenCalledWith({preventScroll: true});
+        expect(element.hasAttribute('tabindex')).toBe(false);
+        ccMain.remove();
+    });
+
+    it("Retains normal focus restoration for host-page elements", () => {
+        const element = createNode('button');
+        appendChild(document.body, element);
+        const focusSpy = jest.spyOn(element, 'focus');
+
+        focus(element);
+
+        expect(focusSpy).toHaveBeenCalledWith();
+        element.remove();
+    });
+
+    it("Falls back when focus options are unsupported", () => {
+        const ccMain = createNode('div');
+        const element = createNode('span');
+        ccMain.id = 'cc-main';
+        appendChild(ccMain, element);
+        appendChild(document.body, ccMain);
+        const focusSpy = jest.spyOn(element, 'focus')
+            .mockImplementationOnce(() => { throw new TypeError('Focus options are unsupported'); })
+            .mockImplementation(() => {});
+
+        focus(element);
+
+        expect(focusSpy).toHaveBeenNthCalledWith(1, {preventScroll: true});
+        expect(focusSpy).toHaveBeenNthCalledWith(2);
+        ccMain.remove();
     });
 })


### PR DESCRIPTION
Fixes #833.

CookieConsent can run before its stylesheet has loaded. In that window, focusing one of its internal modal targets can move the host page to the unstyled `#cc-main` content.

This change:

- focuses CookieConsent-owned elements with `{preventScroll: true}`
- preserves plain `focus()` when restoring focus to an element on the host page
- falls back to plain `focus()` in browsers that reject focus options
- tests all three behaviors and the temporary `tabindex` cleanup

Validation:

- `pnpm test` — 9 suites, 122 tests passed
- `pnpm build` — completed successfully