### PR TITLE
fix(core): initialise _dom outside the GUI block so the core build can run

### DIFF
--- a/src/core/global.js
+++ b/src/core/global.js
@@ -306,18 +306,19 @@ export class GlobalState {
             _allScriptTags: []
         };
 
-        //{{START: GUI}}
-
         /**
-         * Pointers to main dom elements
+         * Pointers to main dom elements.
+         *
+         * Not inside a `{{GUI}}` block: the core build strips those, but
+         * `config-init.js` and `utils/general.js` write `_dom._document` and
+         * `_dom._serviceCheckboxInputs[category]` unconditionally, so the
+         * object and these two maps must exist in both builds.
          * @type {DomElements}
          */
         this._dom = {
             _categoryCheckboxInputs: {},
             _serviceCheckboxInputs: {}
         };
-
-        //{{END: GUI}}
 
         /**
          * Callback functions


### PR DESCRIPTION
Reopens #829, which the stale bot closed on 4 September after 37 days without review. Same branch, same commit, still applies cleanly to master.

`dist/core` throws `TypeError: Cannot set properties of undefined` on the very first `run()` call, so that build is unusable as shipped. One file, six lines. The full bundle comes out byte-identical after the change, so nobody on the normal build is affected. Full analysis and verification in #829.